### PR TITLE
fix: adjust go module name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ COPY internal/ internal/
 
 # Build the binary with Search-specific version information
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -ldflags="-X 'go.datum.net/search/internal/version.Version=${VERSION}' \
-              -X 'go.datum.net/search/internal/version.GitCommit=${GIT_COMMIT}' \
-              -X 'go.datum.net/search/internal/version.GitTreeState=${GIT_TREE_STATE}' \
-              -X 'go.datum.net/search/internal/version.BuildDate=${BUILD_DATE}'" \
+    -ldflags="-X 'go.miloapis.net/search/internal/version.Version=${VERSION}' \
+              -X 'go.miloapis.net/search/internal/version.GitCommit=${GIT_COMMIT}' \
+              -X 'go.miloapis.net/search/internal/version.GitTreeState=${GIT_TREE_STATE}' \
+              -X 'go.miloapis.net/search/internal/version.BuildDate=${BUILD_DATE}'" \
     -a -o search ./cmd/search
 
 # Runtime stage

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -38,10 +38,10 @@ tasks:
         echo "Version: ${VERSION}, Commit: ${GIT_COMMIT:0:7}, Tree: ${GIT_TREE_STATE}"
 
         go build \
-          -ldflags="-X 'go.datum.net/search/internal/version.Version=${VERSION}' \
-                    -X 'go.datum.net/search/internal/version.GitCommit=${GIT_COMMIT}' \
-                    -X 'go.datum.net/search/internal/version.GitTreeState=${GIT_TREE_STATE}' \
-                    -X 'go.datum.net/search/internal/version.BuildDate=${BUILD_DATE}'" \
+          -ldflags="-X 'go.miloapis.net/search/internal/version.Version=${VERSION}' \
+                    -X 'go.miloapis.net/search/internal/version.GitCommit=${GIT_COMMIT}' \
+                    -X 'go.miloapis.net/search/internal/version.GitTreeState=${GIT_TREE_STATE}' \
+                    -X 'go.miloapis.net/search/internal/version.BuildDate=${BUILD_DATE}'" \
           -o {{.TOOL_DIR}}/search ./cmd/search
         echo "✅ Binary built: {{.TOOL_DIR}}/search"
     silent: true
@@ -88,8 +88,8 @@ tasks:
         go run k8s.io/code-generator/cmd/deepcopy-gen \
           --go-header-file hack/boilerplate.go.txt \
           --output-file zz_generated.deepcopy.go \
-          --bounding-dirs go.datum.net/search/pkg/apis \
-          go.datum.net/search/pkg/apis/search/v1alpha1
+          --bounding-dirs go.miloapis.net/search/pkg/apis \
+          go.miloapis.net/search/pkg/apis/search/v1alpha1
 
         echo "✅ Code generation complete"
     silent: true

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	searchapiserver "go.datum.net/search/internal/apiserver"
-	"go.datum.net/search/internal/version"
-	"go.datum.net/search/pkg/generated/openapi"
+	searchapiserver "go.miloapis.net/search/internal/apiserver"
+	"go.miloapis.net/search/internal/version"
+	"go.miloapis.net/search/pkg/generated/openapi"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apiopenapi "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericapiserver "k8s.io/apiserver/pkg/server"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.datum.net/search
+module go.miloapis.net/search
 
 go 1.25.0
 

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -11,9 +11,9 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/klog/v2"
 
-	_ "go.datum.net/search/internal/metrics"
-	"go.datum.net/search/pkg/apis/search/install"
-	"go.datum.net/search/pkg/apis/search/v1alpha1"
+	_ "go.miloapis.net/search/internal/metrics"
+	"go.miloapis.net/search/pkg/apis/search/install"
+	"go.miloapis.net/search/pkg/apis/search/v1alpha1"
 )
 
 var (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,22 +10,22 @@ import (
 var (
 	// Version is the semantic version of the Search API server (e.g., "v0.1.0", "v1.2.3")
 	// This can be set via ldflags during build:
-	//   -ldflags="-X 'go.datum.net/search/internal/version.Version=v0.1.0'"
+	//   -ldflags="-X 'go.miloapis.net/search/internal/version.Version=v0.1.0'"
 	Version = "dev"
 
 	// GitCommit is the git commit hash of the build
 	// This can be set via ldflags during build:
-	//   -ldflags="-X 'go.datum.net/search/internal/version.GitCommit=$(git rev-parse HEAD)'"
+	//   -ldflags="-X 'go.miloapis.net/search/internal/version.GitCommit=$(git rev-parse HEAD)'"
 	GitCommit = "unknown"
 
 	// GitTreeState indicates whether the git tree was clean or dirty during build
 	// This can be set via ldflags during build:
-	//   -ldflags="-X 'go.datum.net/search/internal/version.GitTreeState=clean'"
+	//   -ldflags="-X 'go.miloapis.net/search/internal/version.GitTreeState=clean'"
 	GitTreeState = "unknown"
 
 	// BuildDate is the date when the binary was built (RFC3339 format)
 	// This can be set via ldflags during build:
-	//   -ldflags="-X 'go.datum.net/search/internal/version.BuildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')'"
+	//   -ldflags="-X 'go.miloapis.net/search/internal/version.BuildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')'"
 	BuildDate = "unknown"
 )
 

--- a/pkg/apis/search/install/install.go
+++ b/pkg/apis/search/install/install.go
@@ -4,7 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	"go.datum.net/search/pkg/apis/search/v1alpha1"
+	"go.miloapis.net/search/pkg/apis/search/v1alpha1"
 )
 
 // Install registers the API group and adds types to a scheme


### PR DESCRIPTION
The go module name was supposed to be under the milo api go module and not the datum one.