### PR TITLE
refactor: verify the index exists instead of relaying in string comparison

### DIFF
--- a/internal/controllers/policy/policy_controller.go
+++ b/internal/controllers/policy/policy_controller.go
@@ -547,11 +547,10 @@ func (f *resourceIndexPolicyFinalizer) Finalize(ctx context.Context, obj client.
 	}
 
 	// Remove all documents then delete the index itself.
-	searchIndex := policy.Status.IndexName
-	if searchIndex == "" {
-		log.Info("No index name found, skipping cleanup")
-		return finalizer.Result{}, nil
-	}
+	// Calculate instead of using from status.indexName to avoid race condition
+	// where the index status update was not made
+	searchIndex := utils.GetSearchIndex(policy.Spec.TargetResource)
+
 	log.Info("Deleting all documents from search index", "index", searchIndex)
 	if err := f.SearchSDK.DeleteAllDocuments(searchIndex); err != nil {
 		log.Error(err, "Failed to delete all documents from search index")

--- a/pkg/meilisearch/sdk_client.go
+++ b/pkg/meilisearch/sdk_client.go
@@ -340,12 +340,17 @@ func (s *SDKClient) UpdateSearchableAttributes(indexUID string, attributes []str
 // DeleteAllDocuments deletes all documents from the given index and waits for the
 // task to complete before returning. If the index does not exist, it is a no-op.
 func (s *SDKClient) DeleteAllDocuments(indexUID string) error {
+	exists, err := s.IndexExists(indexUID)
+	if err != nil {
+		return fmt.Errorf("failed to check if index %s exists: %w", indexUID, err)
+	}
+	if !exists {
+		klog.Infof("Index %s not found, skipping document deletion", indexUID)
+		return nil
+	}
+
 	resp, err := s.client.Index(indexUID).DeleteAllDocuments(nil)
 	if err != nil {
-		if strings.Contains(err.Error(), "index_not_found") {
-			klog.Infof("Index %s not found, skipping document deletion", indexUID)
-			return nil
-		}
 		return fmt.Errorf("failed to delete all documents from index %s: %w", indexUID, err)
 	}
 
@@ -365,12 +370,17 @@ func (s *SDKClient) DeleteAllDocuments(indexUID string) error {
 // DeleteIndex deletes the index with the given UID and waits for the task to
 // complete. If the index does not exist, it is a no-op.
 func (s *SDKClient) DeleteIndex(indexUID string) error {
+	exists, err := s.IndexExists(indexUID)
+	if err != nil {
+		return fmt.Errorf("failed to check if index %s exists: %w", indexUID, err)
+	}
+	if !exists {
+		klog.Infof("Index %s not found, skipping deletion", indexUID)
+		return nil
+	}
+
 	resp, err := s.client.DeleteIndex(indexUID)
 	if err != nil {
-		if strings.Contains(err.Error(), "index_not_found") {
-			klog.Infof("Index %s not found, skipping deletion", indexUID)
-			return nil
-		}
 		return fmt.Errorf("failed to delete index %s: %w", indexUID, err)
 	}
 


### PR DESCRIPTION
This PR refactors the meilisearchSDK to eliminate the use of string comparison for determining the existence of an index.

Additionally, the ResourceIndexPolicy finalizer is updated to utilize the new, improved SDK. Consequently, the finalizer can now complete even if the index does not exist.