### PR TITLE
fix: remove unused placeholder secrets and standardize meilisearch auth

### DIFF
--- a/config/base/apiserver/deployment.yaml
+++ b/config/base/apiserver/deployment.yaml
@@ -100,11 +100,11 @@ spec:
           value: ""
         - name: MEILISEARCH_DOMAIN
           value: "http://meilisearch.meilisearch-system.svc.cluster.local:7700"
-        envFrom:
-        - secretRef:
-            name: search-apiserver
-        # TEMPLATE NOTE: Add your service-specific environment variables here
-        # Example: database credentials, API keys, configuration values
+        - name: MEILISEARCH_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: meilisearch-master-key
+              key: MEILI_MASTER_KEY
         resources:
           requests:
             cpu: 100m

--- a/config/base/controller-manager/deployment.yaml
+++ b/config/base/controller-manager/deployment.yaml
@@ -80,11 +80,8 @@ spec:
         - name: MEILISEARCH_API_KEY
           valueFrom:
             secretKeyRef:
-              name: search-controller-manager
-              key: MEILISEARCH_API_KEY
-        envFrom:
-        - secretRef:
-            name: search-controller-manager
+              name: meilisearch-master-key
+              key: MEILI_MASTER_KEY
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/config/base/resource-indexer/deployment.yaml
+++ b/config/base/resource-indexer/deployment.yaml
@@ -47,7 +47,9 @@ spec:
           value: "AUDIT_EVENTS"
         - name: MEILISEARCH_DOMAIN
           value: "http://meilisearch.meilisearch-system.svc.cluster.local:7700"
-        envFrom:
-        - secretRef:
-            name: search-indexer
-        
+        - name: MEILISEARCH_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: meilisearch-master-key
+              key: MEILI_MASTER_KEY
+


### PR DESCRIPTION
## Summary

- Remove unused `envFrom: secretRef` placeholders from all deployments
- Standardize `MEILISEARCH_API_KEY` to use `meilisearch-master-key` secret

## Problem

Deployments referenced secrets that were never created, causing pods to fail with `CreateContainerConfigError`:

| Deployment | Missing Secret |
|------------|----------------|
| search-apiserver | `search-apiserver` |
| search-controller-manager | `search-controller-manager` |
| resource-indexer | `search-indexer` |

These `envFrom: secretRef` placeholders were intended as extension points but required operators to create empty secrets just to start the pods.

## Solution

1. Remove all `envFrom: secretRef` placeholders - operators can still inject env vars via kustomize patches
2. Change `MEILISEARCH_API_KEY` to reference `meilisearch-master-key` secret (created by meilisearch deployment) instead of component-specific secrets

## Test plan

- [x] Verify kustomize build succeeds for all overlays
- [x] Deploy to staging and verify pods start without `CreateContainerConfigError`
- [x] Verify meilisearch authentication works with the new secret reference