### PR TITLE
fix: resolve OpenAPI spec $ref naming mismatch

### DIFF
--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -190,6 +190,12 @@ func (o *SearchServerOptions) Config() (*searchapiserver.Config, error) {
 		friendlyName, extensions := namer.GetDefinitionName(name)
 		return openapiutil.ToRESTFriendlyName(friendlyName), extensions
 	}
+	// Nil out the pre-computed Definitions map so the OpenAPI builder re-invokes
+	// GetDefinitions with a fresh ref callback that uses the updated GetDefinitionName
+	// above. Without this, the builder uses the pre-computed $refs (which were built
+	// before GetDefinitionName was overridden) and the schema component keys diverge
+	// from the $ref values in the generated spec.
+	genericConfig.OpenAPIV3Config.Definitions = nil
 
 	// Configure OpenAPI v2
 	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitionsWithUnstructured, namer)


### PR DESCRIPTION
## Summary

- `DefaultOpenAPIV3Config` pre-computes the `Definitions` map immediately using the default `GetDefinitionName` (without `ToRESTFriendlyName`)
- The kube-openapi builder (`builder3/openapi.go:231`) prefers the pre-computed `Definitions` map and skips calling `GetDefinitions` again
- When `main.go` overrides `GetDefinitionName` to add `ToRESTFriendlyName`, schema component keys get the friendly names but `$ref` strings inside the pre-computed map do not
- This produced a spec where `$ref` values like `#/components/schemas/go.miloapis.net~1search~1pkg~1apis~1search~1v1alpha1.ResourceSearchQuerySpec` did not match schema keys like `net.miloapis.go.search.pkg.apis.search.v1alpha1.ResourceSearchQuerySpec`, breaking `openapi-ts` and other tools that resolve refs

**Fix**: Set `Definitions = nil` after overriding `GetDefinitionName`. The builder then falls through to `GetDefinitions`, building fresh `$ref`s using the corrected `GetDefinitionName`. Both schema keys and `$ref` values are now consistent.

## Test plan

- [ ] Build passes: `go build ./cmd/search/...`
- [ ] Deploy to staging and fetch the OpenAPI spec — verify `$ref` values in the spec match schema component keys (e.g. `net.miloapis.go.search.pkg.apis.search.v1alpha1.ResourceSearchQuerySpec` appears in both)
- [ ] Run `openapi-ts` against the staging spec — confirm generation succeeds without `Reference not found` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)