### PR TITLE
refactor: Consolidate Meilisearch API key secret generation

### DIFF
--- a/config/base/controller-manager/deployment.yaml
+++ b/config/base/controller-manager/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - name: MEILISEARCH_DOMAIN
           value: "http://meilisearch.meilisearch-system.svc.cluster.local:7700"
         - name: MEILISEARCH_TASK_WAIT_TIMEOUT
-          value: "30s"
+          value: "3s"
         - name: MAX_CEL_DEPTH
           value: "10"
         - name: NATS_URL

--- a/config/overlays/ci/kustomization.yaml
+++ b/config/overlays/ci/kustomization.yaml
@@ -56,12 +56,7 @@ patches:
         value: false
 
 secretGenerator:
-- name: search-controller-manager
+- name: meilisearch-master-key
   literals:
-  - MEILISEARCH_API_KEY=search-master-key
-- name: search-indexer
-  literals:
-  - MEILISEARCH_API_KEY=search-master-key
-- name: search-apiserver
-  literals:
-  - MEILISEARCH_API_KEY=search-master-key
+  - MEILI_MASTER_KEY=search-master-key
+

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -46,12 +46,6 @@ patches:
           cert-manager.io/inject-ca-from: search-system/search-ca
 
 secretGenerator:
-- name: search-controller-manager
+- name: meilisearch-master-key
   literals:
-  - MEILISEARCH_API_KEY=search-master-key
-- name: search-indexer
-  literals:
-  - MEILISEARCH_API_KEY=search-master-key
-- name: search-apiserver
-  literals:
-  - MEILISEARCH_API_KEY=search-master-key
+  - MEILI_MASTER_KEY=search-master-key


### PR DESCRIPTION
This PR resolves an error in the development environment that was causing end-to-end tests to fail.

The issue stemmed from the CI and development overlays failing to set the correct secrets for the deployments because the deployment secrets had been updated before the overlays were applied.

Additionally, the MEILISEARCH_TASK_WAIT_TIMEOUT variable is adjusted from 30 seconds to 3 seconds. This wait is a synchronous wait used for deleting documents and indexes, and it was causing the tests to fail due to a time limit being exceeded.