### PR TITLE
fix: rename ClusterRole to avoid collision with milo-controller-manager

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -121,7 +121,7 @@ tasks:
       - "\"{{.TOOL_DIR}}/controller-gen\" object paths=\"./pkg/apis/...\""
       # Generate RBAC rules for the controllers.
       - echo "Generating RBAC rules for the controllers..."
-      - "\"{{.TOOL_DIR}}/controller-gen\" rbac:roleName=milo-controller-manager paths=\"./internal/controllers/...\" output:dir=\"./config/overlays/controller-manager/core-control-plane/rbac\""
+      - "\"{{.TOOL_DIR}}/controller-gen\" rbac:roleName=search-controller-manager paths=\"./internal/controllers/...\" output:dir=\"./config/overlays/controller-manager/core-control-plane/rbac\""
       - "\"{{.TOOL_DIR}}/controller-gen\" rbac:roleName=milo-resource-indexer paths=\"./internal/indexer/...\" output:dir=\"./config/overlays/resource-indexer/core-control-plane/rbac\""
       - task: generate:openapi
     silent: true

--- a/config/overlays/controller-manager/core-control-plane/rbac/role.yaml
+++ b/config/overlays/controller-manager/core-control-plane/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: milo-controller-manager
+  name: search-controller-manager
 rules:
 - apiGroups:
   - '*'

--- a/config/overlays/controller-manager/core-control-plane/rbac/rolebinding.yaml
+++ b/config/overlays/controller-manager/core-control-plane/rbac/rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: milo-controller-manager
+  name: search-controller-manager
 subjects:
   - kind: ServiceAccount
     name: search-controller-manager


### PR DESCRIPTION
## Summary

- Renames the search system's ClusterRole from `milo-controller-manager` to `search-controller-manager`
- This ClusterRole name collided with Milo's own ClusterRole, causing Flux to intermittently overwrite RBAC permissions
- Root cause of ProjectStuckCreatingSLOViolation alerts in production -- every ~1 minute, the search-system Kustomization stripped the `infrastructure.miloapis.com/projectcontrolplanes` create permission from the shared ClusterRole

## Evidence

GCP audit logs confirmed the collision:
- At `13:28:56Z`, `search-system` Kustomization patched `clusterroles/milo-controller-manager` with search-only permissions
- At `13:29:07Z`, `milo-controller-manager` Kustomization patched it back to the full ruleset
- Any project creation during the ~11s window between these patches fails with RBAC forbidden

## Test plan

- [ ] Verify search-controller-manager ClusterRole is created with correct permissions
- [ ] Verify milo-controller-manager ClusterRole is no longer overwritten by search-system
- [ ] Confirm ProjectStuckCreatingSLOViolation alerts stop firing