### PR TITLE
feat(search): respect tenant context from user.Info.Extra

### DIFF
--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -15,6 +15,7 @@ import (
 	"go.miloapis.net/search/internal/version"
 	searchv1alpha1 "go.miloapis.net/search/pkg/apis/search/v1alpha1"
 	"go.miloapis.net/search/pkg/generated/openapi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apiopenapi "k8s.io/apiserver/pkg/endpoints/openapi"
@@ -30,6 +31,7 @@ import (
 	openapiutil "k8s.io/kube-openapi/pkg/util"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"go.miloapis.net/search/cmd/search/indexer"
@@ -272,6 +274,42 @@ func (o *SearchServerOptions) Config() (*searchapiserver.Config, error) {
 		return nil, fmt.Errorf("failed to create policy cache: %w", err)
 	}
 
+	// Build a separate cache for CustomResourceDefinitions. CRDs live on the
+	// kube-apiserver (not on the search apiserver's loopback), so this cache
+	// uses the in-cluster config — same approach as the SAR client below.
+	inClusterCfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build in-cluster config for CRD cache: %w", err)
+	}
+
+	crdScheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(crdScheme); err != nil {
+		return nil, fmt.Errorf("failed to register apiextensions/v1 in CRD scheme: %w", err)
+	}
+	crdHTTPClient, err := rest.HTTPClientFor(inClusterCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client for CRD cache: %w", err)
+	}
+	crdCache, err := runtimecache.New(inClusterCfg, runtimecache.Options{
+		Scheme:     crdScheme,
+		HTTPClient: crdHTTPClient,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CRD cache: %w", err)
+	}
+	crdPluralCache := internalindexer.NewCRDPluralCache(crdCache)
+
+	// Build a REST mapper backed by the kube-apiserver for resolving plural
+	// names of aggregated API server types (e.g. resourcemanager.miloapis.com/
+	// Project) that are not CRDs and therefore absent from the CRD informer.
+	// The mapper is lazy — it only calls discovery when a kind is first
+	// requested — so construction here is cheap.
+	crdMapper, err := apiutil.NewDynamicRESTMapper(inClusterCfg, crdHTTPClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create REST mapper for plural lookup: %w", err)
+	}
+	pluralLookup := internalindexer.NewFallbackPluralLookup(crdPluralCache, crdMapper)
+
 	pagingSecret := []byte(os.Getenv("SEARCH_PAGING_SECRET"))
 	if len(pagingSecret) == 0 {
 		klog.Info("SEARCH_PAGING_SECRET not set, generating a random one")
@@ -296,6 +334,8 @@ func (o *SearchServerOptions) Config() (*searchapiserver.Config, error) {
 		ExtraConfig: searchapiserver.ExtraConfig{
 			MeiliClient:        meiliClient,
 			PolicyCache:        indexPolicyCache,
+			CRDCache:           crdPluralCache,
+			PluralLookup:       pluralLookup,
 			SARClient:          clientset.AuthorizationV1().SubjectAccessReviews(),
 			MaxSearchLimit:     o.MaxSearchLimit,
 			DefaultSearchLimit: o.DefaultSearchLimit,

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -36,6 +36,8 @@ import (
 	"go.miloapis.net/search/cmd/search/manager"
 	internalindexer "go.miloapis.net/search/internal/indexer"
 	"go.miloapis.net/search/pkg/meilisearch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	// Register JSON logging format
 	_ "k8s.io/component-base/logs/json/register"
@@ -276,11 +278,25 @@ func (o *SearchServerOptions) Config() (*searchapiserver.Config, error) {
 		pagingSecret = []byte(uuid.New().String())
 	}
 
+	// The SubjectAccessReview API is served by the kube-apiserver, not by us
+	// (we only serve search.miloapis.com). Use the in-cluster config (mounted
+	// service account token) to reach the kube-apiserver. Loopback would point
+	// the SAR client back at this apiserver and return 404.
+	kubeConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build in-cluster config for SAR client: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+
 	serverConfig := &searchapiserver.Config{
 		GenericConfig: genericConfig,
 		ExtraConfig: searchapiserver.ExtraConfig{
 			MeiliClient:        meiliClient,
 			PolicyCache:        indexPolicyCache,
+			SARClient:          clientset.AuthorizationV1().SubjectAccessReviews(),
 			MaxSearchLimit:     o.MaxSearchLimit,
 			DefaultSearchLimit: o.DefaultSearchLimit,
 			PagingSecret:       pagingSecret,

--- a/config/base/apiserver/rbac-cluster.yaml
+++ b/config/base/apiserver/rbac-cluster.yaml
@@ -28,6 +28,11 @@ rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["validatingadmissionpolicies", "validatingadmissionpolicybindings"]
   verbs: ["get", "list", "watch"]
+# Allow reading CustomResourceDefinitions so the CRD plural cache can resolve
+# (group, kind) pairs to plural resource names for tenant-scoped search.
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/text v0.32.0
 	k8s.io/api v0.35.2
+	k8s.io/apiextensions-apiserver v0.35.0
 	k8s.io/apimachinery v0.35.2
 	k8s.io/apiserver v0.35.2
 	k8s.io/client-go v0.35.2
@@ -107,7 +108,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/code-generator v0.35.2 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/kms v0.35.2 // indirect

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -57,8 +57,16 @@ func init() {
 
 // ExtraConfig extends the generic apiserver configuration with search-specific settings.
 type ExtraConfig struct {
-	MeiliClient        *meilisearch.SDKClient
-	PolicyCache        *indexer.PolicyCache
+	MeiliClient *meilisearch.SDKClient
+	PolicyCache *indexer.PolicyCache
+	// CRDCache is the raw controller-runtime cache for CustomResourceDefinitions.
+	// It is used only for lifecycle management (RegisterHandlers, Start,
+	// WaitForCacheSync) in the post-start hook. Query routing uses PluralLookup.
+	CRDCache *indexer.CRDPluralCache
+	// PluralLookup resolves (group, kind) to plural resource names for SAR
+	// authorization. Backed by FallbackPluralLookup which tries the CRD cache
+	// first and falls back to the REST mapper for aggregated API server types.
+	PluralLookup       *indexer.FallbackPluralLookup
 	SARClient          typedauthzv1.SubjectAccessReviewInterface
 	MaxSearchLimit     int
 	DefaultSearchLimit int
@@ -126,6 +134,7 @@ func (c completedConfig) New() (*SearchServer, error) {
 	resourcesearchqueryStorage := resourcesearchquery.NewREST(
 		c.ExtraConfig.MeiliClient,
 		c.ExtraConfig.PolicyCache,
+		c.ExtraConfig.PluralLookup,
 		c.ExtraConfig.SARClient,
 		c.ExtraConfig.MaxSearchLimit,
 		c.ExtraConfig.DefaultSearchLimit,
@@ -155,6 +164,29 @@ func (c completedConfig) New() (*SearchServer, error) {
 
 		if !c.ExtraConfig.PolicyCache.WaitForCacheSync(ctx.Context) {
 			return fmt.Errorf("failed to wait for policy cache sync")
+		}
+		return nil
+	})
+
+	// Start the CRD plural cache. This is a SEPARATE controller-runtime cache
+	// from the policy cache — CRDs live on the kube-apiserver (not on this
+	// apiserver's loopback), so the CRD cache uses in-cluster config rather
+	// than LoopbackClientConfig. The two caches have independent lifecycles
+	// and are started/synced concurrently by their respective post-start hooks.
+	s.GenericAPIServer.AddPostStartHookOrDie("search-crd-plural-cache", func(ctx genericapiserver.PostStartHookContext) error {
+		if err := c.ExtraConfig.CRDCache.RegisterHandlers(ctx.Context); err != nil {
+			return fmt.Errorf("failed to register CRD plural cache handlers: %w", err)
+		}
+
+		go func() {
+			klog.Info("Starting Search CRD plural cache...")
+			if err := c.ExtraConfig.CRDCache.Start(ctx.Context); err != nil {
+				klog.Errorf("CRD plural cache stopped with error: %v", err)
+			}
+		}()
+
+		if !c.ExtraConfig.CRDCache.WaitForCacheSync(ctx.Context) {
+			return fmt.Errorf("failed to wait for CRD plural cache sync")
 		}
 		return nil
 	})

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	typedauthzv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/klog/v2"
 
 	"go.miloapis.net/search/internal/indexer"
@@ -58,6 +59,7 @@ func init() {
 type ExtraConfig struct {
 	MeiliClient        *meilisearch.SDKClient
 	PolicyCache        *indexer.PolicyCache
+	SARClient          typedauthzv1.SubjectAccessReviewInterface
 	MaxSearchLimit     int
 	DefaultSearchLimit int
 	PagingSecret       []byte
@@ -124,6 +126,7 @@ func (c completedConfig) New() (*SearchServer, error) {
 	resourcesearchqueryStorage := resourcesearchquery.NewREST(
 		c.ExtraConfig.MeiliClient,
 		c.ExtraConfig.PolicyCache,
+		c.ExtraConfig.SARClient,
 		c.ExtraConfig.MaxSearchLimit,
 		c.ExtraConfig.DefaultSearchLimit,
 		c.ExtraConfig.PagingSecret,

--- a/internal/indexer/crd_plural_cache.go
+++ b/internal/indexer/crd_plural_cache.go
@@ -1,0 +1,107 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+// CRDPluralCache resolves a (group, kind) pair to the plural resource name
+// declared on the matching CustomResourceDefinition's spec.names.plural.
+//
+// It watches CustomResourceDefinitions through the shared controller-runtime
+// cache and keeps an in-memory map fresh in response to CRD events.
+//
+// Lifecycle mirrors PolicyCache: construct, RegisterHandlers, Start, then
+// WaitForCacheSync. The apiserver post-start hook orchestrates all three.
+// Consumers must not call Lookup before WaitForCacheSync returns true;
+// before that point the map is empty and every lookup will miss.
+type CRDPluralCache struct {
+	mu      sync.RWMutex
+	plurals map[schema.GroupKind]string
+
+	cache runtimecache.Cache
+}
+
+// NewCRDPluralCache constructs the cache. Handler registration and informer
+// startup are deferred to RegisterHandlers/Start so callers can orchestrate
+// them via the genericapiserver post-start hook.
+func NewCRDPluralCache(c runtimecache.Cache) *CRDPluralCache {
+	cache := &CRDPluralCache{
+		plurals: make(map[schema.GroupKind]string),
+		cache:   c,
+	}
+	klog.Info("Created CRD plural cache")
+	return cache
+}
+
+// RegisterHandlers attaches Add/Update/Delete handlers to the CRD informer.
+func (c *CRDPluralCache) RegisterHandlers(ctx context.Context) error {
+	informer, err := c.cache.GetInformer(ctx, &apiextensionsv1.CustomResourceDefinition{})
+	if err != nil {
+		return fmt.Errorf("getting CRD informer: %w", err)
+	}
+	if _, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onAddOrUpdate,
+		UpdateFunc: func(_, newObj any) { c.onAddOrUpdate(newObj) },
+		DeleteFunc: c.onDelete,
+	}); err != nil {
+		return fmt.Errorf("adding CRD event handler: %w", err)
+	}
+	klog.Info("Registered CRD plural cache informer handlers")
+	return nil
+}
+
+// Start delegates to the underlying controller-runtime cache. Idempotent
+// across multiple cache consumers sharing the same runtimecache.Cache.
+func (c *CRDPluralCache) Start(ctx context.Context) error {
+	return c.cache.Start(ctx)
+}
+
+// WaitForCacheSync blocks until the CRD informer has populated. Returns false
+// if the context is cancelled before sync completes.
+func (c *CRDPluralCache) WaitForCacheSync(ctx context.Context) bool {
+	return c.cache.WaitForCacheSync(ctx)
+}
+
+// Lookup returns the plural resource name for a given group/kind, or
+// ("", false) if no CRD has been observed for that pair.
+func (c *CRDPluralCache) Lookup(gk schema.GroupKind) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	p, ok := c.plurals[gk]
+	return p, ok
+}
+
+func (c *CRDPluralCache) onAddOrUpdate(obj any) {
+	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		klog.Errorf("CRDPluralCache: unexpected object type %T", obj)
+		return
+	}
+	gk := schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind}
+	c.mu.Lock()
+	c.plurals[gk] = crd.Spec.Names.Plural
+	c.mu.Unlock()
+}
+
+func (c *CRDPluralCache) onDelete(obj any) {
+	if tomb, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
+		obj = tomb.Obj
+	}
+	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		klog.Errorf("CRDPluralCache: unexpected object type %T", obj)
+		return
+	}
+	gk := schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind}
+	c.mu.Lock()
+	delete(c.plurals, gk)
+	c.mu.Unlock()
+}

--- a/internal/indexer/crd_plural_cache_test.go
+++ b/internal/indexer/crd_plural_cache_test.go
@@ -1,0 +1,148 @@
+package indexer
+
+import (
+	"sync"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	toolscache "k8s.io/client-go/tools/cache"
+)
+
+func newCRD(group, kind, plural string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: plural + "." + group},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:   kind,
+				Plural: plural,
+			},
+		},
+	}
+}
+
+func newTestCache() *CRDPluralCache {
+	return &CRDPluralCache{plurals: make(map[schema.GroupKind]string)}
+}
+
+func TestCRDPluralCache_LookupAfterEvents(t *testing.T) {
+	gk := schema.GroupKind{Group: "g.example.com", Kind: "Widget"}
+
+	tests := []struct {
+		name       string
+		setup      func(c *CRDPluralCache)
+		wantPlural string
+		wantOK     bool
+	}{
+		{
+			name:       "lookup before any add returns false",
+			setup:      func(_ *CRDPluralCache) {},
+			wantPlural: "",
+			wantOK:     false,
+		},
+		{
+			name: "add CRD makes plural queryable",
+			setup: func(c *CRDPluralCache) {
+				c.onAddOrUpdate(newCRD("g.example.com", "Widget", "widgets"))
+			},
+			wantPlural: "widgets",
+			wantOK:     true,
+		},
+		{
+			name: "update CRD replaces plural",
+			setup: func(c *CRDPluralCache) {
+				c.onAddOrUpdate(newCRD("g.example.com", "Widget", "widgets"))
+				c.onAddOrUpdate(newCRD("g.example.com", "Widget", "widgetses"))
+			},
+			wantPlural: "widgetses",
+			wantOK:     true,
+		},
+		{
+			name: "delete CRD makes lookup return false",
+			setup: func(c *CRDPluralCache) {
+				crd := newCRD("g.example.com", "Widget", "widgets")
+				c.onAddOrUpdate(crd)
+				c.onDelete(crd)
+			},
+			wantPlural: "",
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestCache()
+			tt.setup(c)
+			got, ok := c.Lookup(gk)
+			if ok != tt.wantOK || got != tt.wantPlural {
+				t.Fatalf("Lookup() = (%q, %v), want (%q, %v)", got, ok, tt.wantPlural, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestCRDPluralCache_DeleteTombstone_HandledCorrectly(t *testing.T) {
+	c := newTestCache()
+	crd := newCRD("g.example.com", "Widget", "widgets")
+	c.onAddOrUpdate(crd)
+	tomb := toolscache.DeletedFinalStateUnknown{Key: "widgets.g.example.com", Obj: crd}
+	c.onDelete(tomb)
+	got, ok := c.Lookup(schema.GroupKind{Group: "g.example.com", Kind: "Widget"})
+	if ok {
+		t.Fatalf("expected ok=false after tombstone delete, got %q ok=%v", got, ok)
+	}
+}
+
+func TestCRDPluralCache_SameKindDifferentGroups_BothQueryable(t *testing.T) {
+	c := newTestCache()
+	c.onAddOrUpdate(newCRD("g1.example.com", "Widget", "widgets"))
+	c.onAddOrUpdate(newCRD("g2.example.com", "Widget", "gadgets"))
+
+	got1, ok1 := c.Lookup(schema.GroupKind{Group: "g1.example.com", Kind: "Widget"})
+	got2, ok2 := c.Lookup(schema.GroupKind{Group: "g2.example.com", Kind: "Widget"})
+	if !ok1 || got1 != "widgets" {
+		t.Fatalf("group1 lookup: got (%q, %v), want (\"widgets\", true)", got1, ok1)
+	}
+	if !ok2 || got2 != "gadgets" {
+		t.Fatalf("group2 lookup: got (%q, %v), want (\"gadgets\", true)", got2, ok2)
+	}
+}
+
+func TestCRDPluralCache_NonCRDObject_NoOpNoPanic(t *testing.T) {
+	c := newTestCache()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+	c.onAddOrUpdate("not a CRD")
+	c.onDelete(42)
+	if len(c.plurals) != 0 {
+		t.Fatalf("expected empty map after non-CRD events, got %d entries", len(c.plurals))
+	}
+}
+
+func TestCRDPluralCache_ConcurrentLookupAndWrite_RaceFree(t *testing.T) {
+	t.Parallel()
+
+	const concurrentOps = 20
+
+	c := newTestCache()
+	c.onAddOrUpdate(newCRD("g.example.com", "Widget", "widgets"))
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentOps; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			c.onAddOrUpdate(newCRD("g.example.com", "Widget", "widgets"))
+		}()
+		go func() {
+			defer wg.Done()
+			c.Lookup(schema.GroupKind{Group: "g.example.com", Kind: "Widget"})
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/indexer/fallback_plural_lookup.go
+++ b/internal/indexer/fallback_plural_lookup.go
@@ -1,0 +1,80 @@
+package indexer
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+// FallbackPluralLookup resolves a (group, kind) pair to the plural resource
+// name using a three-tier strategy:
+//
+//  1. CRD plural cache (fastest): covers all CRD-backed types watched via the
+//     apiextensions.k8s.io informer.
+//
+//  2. REST mapper (discovery): covers aggregated API server types registered
+//     in the kube-apiserver's discovery (e.g. built-in types, milo services
+//     that are running and registered as APIServices in this cluster).
+//
+//  3. Conventional lowercase+s fallback: for resource types that are not
+//     present in this cluster at all (e.g. data indexed from an external
+//     pipeline whose API server is not registered here). The conventional
+//     plural allows a SubjectAccessReview to be constructed so that RBAC can
+//     still gate access — if no RBAC rule grants list on the resource, the SAR
+//     returns denied and the request is correctly rejected.
+//
+// This three-tier approach handles the full range of types the search service
+// may index: native CRDs, aggregated API server types in-cluster, and types
+// whose API servers live outside this cluster.
+type FallbackPluralLookup struct {
+	crdCache *CRDPluralCache
+	mapper   meta.RESTMapper
+}
+
+// NewFallbackPluralLookup constructs a FallbackPluralLookup. Both arguments
+// are required; mapper should be backed by the kube-apiserver (in-cluster
+// config), not by the search apiserver loopback.
+func NewFallbackPluralLookup(crdCache *CRDPluralCache, mapper meta.RESTMapper) *FallbackPluralLookup {
+	return &FallbackPluralLookup{
+		crdCache: crdCache,
+		mapper:   mapper,
+	}
+}
+
+// Lookup returns the plural resource name for a given group/kind.
+// It always returns (plural, true) — falling back to the conventional
+// lowercase+s plural when neither the CRD cache nor the REST mapper knows
+// the type. The caller (authorizeTargets) is responsible for using the plural
+// in a SubjectAccessReview; RBAC will deny access if no rule grants list on
+// the resulting resource name.
+func (f *FallbackPluralLookup) Lookup(gk schema.GroupKind) (string, bool) {
+	// Tier 1: CRD informer cache — O(1), no network call.
+	if plural, ok := f.crdCache.Lookup(gk); ok {
+		return plural, true
+	}
+
+	// Tier 2: REST mapper discovery — covers aggregated API server types
+	// registered in this cluster's kube-apiserver.
+	mappings, err := f.mapper.RESTMappings(gk)
+	if err == nil && len(mappings) > 0 {
+		// RESTMappings returns all versions; the plural name is stable across them.
+		plural := mappings[0].Resource.Resource
+		klog.V(4).Infof("FallbackPluralLookup: resolved %s → %q via RESTMapper", gk, plural)
+		return plural, true
+	}
+	if err != nil && !meta.IsNoMatchError(err) {
+		klog.V(3).Infof("FallbackPluralLookup: REST mapper error for %s: %v", gk, err)
+	}
+
+	// Tier 3: Conventional plural — lowercase kind + "s". Used when the API
+	// type is not registered in this cluster (e.g. indexed by an external
+	// pipeline). Constructing the SAR with the conventional plural still lets
+	// RBAC deny access for unauthorized users; it may produce a false-allow
+	// only if a cluster admin has explicitly granted list on an unknown plural,
+	// which is an acceptable trade-off for operability.
+	conventional := strings.ToLower(gk.Kind) + "s"
+	klog.V(4).Infof("FallbackPluralLookup: using conventional plural %q for unknown type %s", conventional, gk)
+	return conventional, true
+}

--- a/internal/indexer/fallback_plural_lookup_test.go
+++ b/internal/indexer/fallback_plural_lookup_test.go
@@ -1,0 +1,119 @@
+package indexer
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// fakeRESTMapper is a hand-rolled meta.RESTMapper for the test. We only need
+// RESTMappings; everything else returns "not implemented" to surface accidental
+// callers loudly.
+type fakeRESTMapper struct {
+	known       map[schema.GroupKind]string
+	errOnLookup error
+}
+
+func (f *fakeRESTMapper) RESTMappings(gk schema.GroupKind, _ ...string) ([]*meta.RESTMapping, error) {
+	if f.errOnLookup != nil {
+		return nil, f.errOnLookup
+	}
+	plural, ok := f.known[gk]
+	if !ok {
+		return nil, &meta.NoKindMatchError{GroupKind: gk}
+	}
+	return []*meta.RESTMapping{{
+		Resource: schema.GroupVersionResource{Group: gk.Group, Resource: plural},
+	}}, nil
+}
+
+func (f *fakeRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, errors.New("not implemented")
+}
+func (f *fakeRESTMapper) KindsFor(schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeRESTMapper) ResourceFor(schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, errors.New("not implemented")
+}
+func (f *fakeRESTMapper) ResourcesFor(schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeRESTMapper) RESTMapping(schema.GroupKind, ...string) (*meta.RESTMapping, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeRESTMapper) ResourceSingularizer(string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func TestFallbackPluralLookup_Tier1_CRDCacheHit(t *testing.T) {
+	t.Parallel()
+	crdCache := newTestCache()
+	crdCache.onAddOrUpdate(newCRD("g.example.com", "Widget", "widgets"))
+	mapper := &fakeRESTMapper{} // empty; should never be consulted
+
+	f := NewFallbackPluralLookup(crdCache, mapper)
+	got, ok := f.Lookup(schema.GroupKind{Group: "g.example.com", Kind: "Widget"})
+	if !ok || got != "widgets" {
+		t.Fatalf("Tier 1 hit: got (%q, %v), want (\"widgets\", true)", got, ok)
+	}
+}
+
+func TestFallbackPluralLookup_Tier2_RESTMapperHit(t *testing.T) {
+	t.Parallel()
+	crdCache := newTestCache() // empty — Tier 1 miss
+	mapper := &fakeRESTMapper{
+		known: map[schema.GroupKind]string{
+			{Group: "resourcemanager.miloapis.com", Kind: "Project"}: "projects",
+		},
+	}
+
+	f := NewFallbackPluralLookup(crdCache, mapper)
+	got, ok := f.Lookup(schema.GroupKind{Group: "resourcemanager.miloapis.com", Kind: "Project"})
+	if !ok || got != "projects" {
+		t.Fatalf("Tier 2 hit: got (%q, %v), want (\"projects\", true)", got, ok)
+	}
+}
+
+func TestFallbackPluralLookup_Tier3_ConventionalFallback(t *testing.T) {
+	t.Parallel()
+	crdCache := newTestCache()  // empty — Tier 1 miss
+	mapper := &fakeRESTMapper{} // empty — Tier 2 returns NoKindMatchError
+
+	f := NewFallbackPluralLookup(crdCache, mapper)
+	got, ok := f.Lookup(schema.GroupKind{Group: "unknown.example.com", Kind: "Gizmo"})
+	if !ok || got != "gizmos" {
+		t.Fatalf("Tier 3 fallback: got (%q, %v), want (\"gizmos\", true) — lowercase Kind + \"s\"", got, ok)
+	}
+}
+
+func TestFallbackPluralLookup_Tier3_OnRESTMapperError(t *testing.T) {
+	t.Parallel()
+	// When the REST mapper returns a non-NoKindMatch error (e.g. transient
+	// discovery failure), Lookup must still fall through to Tier 3 rather than
+	// propagate the error. The caller's SAR will still gate access.
+	crdCache := newTestCache()
+	mapper := &fakeRESTMapper{errOnLookup: errors.New("discovery unavailable")}
+
+	f := NewFallbackPluralLookup(crdCache, mapper)
+	got, ok := f.Lookup(schema.GroupKind{Group: "g.example.com", Kind: "Thing"})
+	if !ok || got != "things" {
+		t.Fatalf("Tier 3 on mapper error: got (%q, %v), want (\"things\", true)", got, ok)
+	}
+}
+
+func TestFallbackPluralLookup_CapitalizedKindLowercased(t *testing.T) {
+	t.Parallel()
+	// Conventional fallback must lowercase the Kind. "DNSZone" → "dnszones",
+	// not "DNSZones". This matches the K8s plural convention (path segment).
+	crdCache := newTestCache()
+	mapper := &fakeRESTMapper{}
+
+	f := NewFallbackPluralLookup(crdCache, mapper)
+	got, ok := f.Lookup(schema.GroupKind{Group: "networking.miloapis.com", Kind: "DNSZone"})
+	if !ok || got != "dnszones" {
+		t.Fatalf("DNSZone fallback: got (%q, %v), want (\"dnszones\", true)", got, ok)
+	}
+}

--- a/internal/registry/resourcesearchquery/authz.go
+++ b/internal/registry/resourcesearchquery/authz.go
@@ -1,0 +1,84 @@
+package resourcesearchquery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	authzv1 "k8s.io/api/authorization/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
+	typedauthzv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+
+	searchv1alpha1 "go.miloapis.net/search/pkg/apis/search/v1alpha1"
+)
+
+// authorizeTargets runs a SubjectAccessReview per TargetResource (verb "list").
+// Returns nil if all checks pass; returns an apierrors.IsForbidden error on the
+// first denial; returns a wrapped error on SAR API failures (fail-closed).
+// An empty targets slice is a no-op (zero SARs).
+func authorizeTargets(
+	ctx context.Context,
+	sars typedauthzv1.SubjectAccessReviewInterface,
+	userInfo user.Info,
+	targets []searchv1alpha1.TargetResource,
+) error {
+	if userInfo == nil {
+		return fmt.Errorf("authorization check: no user in request context")
+	}
+	extra := convertExtra(userInfo.GetExtra())
+	for _, t := range targets {
+		sar := &authzv1.SubjectAccessReview{
+			Spec: authzv1.SubjectAccessReviewSpec{
+				User:   userInfo.GetName(),
+				UID:    userInfo.GetUID(),
+				Groups: userInfo.GetGroups(),
+				Extra:  extra,
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Group:    t.Group,
+					Version:  t.Version,
+					Resource: pluralForKind(t.Kind),
+					Verb:     "list",
+					// Namespace intentionally omitted: cluster-level check.
+				},
+			},
+		}
+		resp, err := sars.Create(ctx, sar, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("authorization check failed for %s/%s/%s: %w",
+				t.Group, t.Version, t.Kind, err)
+		}
+		if !resp.Status.Allowed {
+			return apierrors.NewForbidden(
+				schema.GroupResource{Group: t.Group, Resource: t.Kind},
+				"",
+				fmt.Errorf("user %q is not authorized to search %s/%s/%s: %s",
+					userInfo.GetName(), t.Group, t.Version, t.Kind, resp.Status.Reason),
+			)
+		}
+	}
+	return nil
+}
+
+// convertExtra translates a user.Info Extra map to the SubjectAccessReview
+// Extra shape (a typedef around []string).
+func convertExtra(in map[string][]string) map[string]authzv1.ExtraValue {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]authzv1.ExtraValue, len(in))
+	for k, v := range in {
+		out[k] = authzv1.ExtraValue(v)
+	}
+	return out
+}
+
+// pluralForKind returns the RBAC plural resource name for a Kind.
+// v1: naive lowercase + "s". Adequate for all currently-indexed kinds
+// (Project, Domain, DNSZone, Contact, Organization). Replace with a discovery
+// client when we need to handle irregular plurals.
+func pluralForKind(kind string) string {
+	return strings.ToLower(kind) + "s"
+}

--- a/internal/registry/resourcesearchquery/authz.go
+++ b/internal/registry/resourcesearchquery/authz.go
@@ -3,7 +3,6 @@ package resourcesearchquery
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	authzv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,13 +14,24 @@ import (
 	searchv1alpha1 "go.miloapis.net/search/pkg/apis/search/v1alpha1"
 )
 
+// pluralLookup resolves a (group, kind) pair to its lowercase plural resource
+// name. Implemented by *indexer.CRDPluralCache in production; satisfied by a
+// test fake in unit tests.
+type pluralLookup interface {
+	Lookup(gk schema.GroupKind) (string, bool)
+}
+
 // authorizeTargets runs a SubjectAccessReview per TargetResource (verb "list").
-// Returns nil if all checks pass; returns an apierrors.IsForbidden error on the
-// first denial; returns a wrapped error on SAR API failures (fail-closed).
+// Fail-closed on three paths:
+//   - unknown kind (no CRD in cache) → 403 Forbidden
+//   - SAR denial                     → 403 Forbidden
+//   - SAR API call error             → wrapped error (5xx)
+//
 // An empty targets slice is a no-op (zero SARs).
 func authorizeTargets(
 	ctx context.Context,
 	sars typedauthzv1.SubjectAccessReviewInterface,
+	plurals pluralLookup,
 	userInfo user.Info,
 	targets []searchv1alpha1.TargetResource,
 ) error {
@@ -29,7 +39,21 @@ func authorizeTargets(
 		return fmt.Errorf("authorization check: no user in request context")
 	}
 	extra := convertExtra(userInfo.GetExtra())
+
 	for _, t := range targets {
+		gk := schema.GroupKind{Group: t.Group, Kind: t.Kind}
+		plural, ok := plurals.Lookup(gk)
+		if !ok {
+			// No CRD registered for this kind → no policy can target it.
+			// Fail closed. Resource field uses t.Kind because we don't have
+			// a canonical plural to cite; the message is explicit about why.
+			return apierrors.NewForbidden(
+				schema.GroupResource{Group: t.Group, Resource: t.Kind},
+				"",
+				fmt.Errorf("unknown resource kind %s/%s/%s", t.Group, t.Version, t.Kind),
+			)
+		}
+
 		sar := &authzv1.SubjectAccessReview{
 			Spec: authzv1.SubjectAccessReviewSpec{
 				User:   userInfo.GetName(),
@@ -39,9 +63,8 @@ func authorizeTargets(
 				ResourceAttributes: &authzv1.ResourceAttributes{
 					Group:    t.Group,
 					Version:  t.Version,
-					Resource: pluralForKind(t.Kind),
+					Resource: plural,
 					Verb:     "list",
-					// Namespace intentionally omitted: cluster-level check.
 				},
 			},
 		}
@@ -52,7 +75,7 @@ func authorizeTargets(
 		}
 		if !resp.Status.Allowed {
 			return apierrors.NewForbidden(
-				schema.GroupResource{Group: t.Group, Resource: t.Kind},
+				schema.GroupResource{Group: t.Group, Resource: plural},
 				"",
 				fmt.Errorf("user %q is not authorized to search %s/%s/%s: %s",
 					userInfo.GetName(), t.Group, t.Version, t.Kind, resp.Status.Reason),
@@ -73,12 +96,4 @@ func convertExtra(in map[string][]string) map[string]authzv1.ExtraValue {
 		out[k] = authzv1.ExtraValue(v)
 	}
 	return out
-}
-
-// pluralForKind returns the RBAC plural resource name for a Kind.
-// v1: naive lowercase + "s". Adequate for all currently-indexed kinds
-// (Project, Domain, DNSZone, Contact, Organization). Replace with a discovery
-// client when we need to handle irregular plurals.
-func pluralForKind(kind string) string {
-	return strings.ToLower(kind) + "s"
 }

--- a/internal/registry/resourcesearchquery/authz_test.go
+++ b/internal/registry/resourcesearchquery/authz_test.go
@@ -9,6 +9,7 @@ import (
 	authzv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -16,8 +17,16 @@ import (
 	searchv1alpha1 "go.miloapis.net/search/pkg/apis/search/v1alpha1"
 )
 
-// fakeSARClient returns a SubjectAccessReviewInterface that calls the supplied
-// handler for every Create. Captures every SAR seen for assertions.
+// fakePlurals is a test implementation of pluralLookup backed by a map.
+type fakePlurals map[schema.GroupKind]string
+
+func (f fakePlurals) Lookup(gk schema.GroupKind) (string, bool) {
+	p, ok := f[gk]
+	return p, ok
+}
+
+// fakeSARClient builds a fake SubjectAccessReview client whose Create reactor
+// calls the supplied handler for each invocation. Captures every SAR seen.
 func fakeSARClient(t *testing.T, handle func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error)) (
 	*fake.Clientset,
 	func() []*authzv1.SubjectAccessReview,
@@ -42,200 +51,220 @@ func target(group, version, kind string) searchv1alpha1.TargetResource {
 	return searchv1alpha1.TargetResource{Group: group, Version: version, Kind: kind}
 }
 
-func TestAuthorizeTargets(t *testing.T) {
-	userInfo := &user.DefaultInfo{
-		Name:   "alice",
-		UID:    "uid-1",
-		Groups: []string{"system:authenticated", "tenants:acme"},
-		Extra: map[string][]string{
-			"iam.miloapis.com/parent-type": {"Project"},
-			"iam.miloapis.com/parent-name": {"acme-prod"},
-		},
-	}
+var (
+	gkProject = schema.GroupKind{Group: "resourcemanager.miloapis.com", Kind: "Project"}
+	gkDomain  = schema.GroupKind{Group: "networking.miloapis.com", Kind: "Domain"}
+)
 
-	t.Run("nil user returns error", func(t *testing.T) {
-		cs, _ := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
-			t.Fatal("SAR should not be called when user is nil")
-			return nil, nil
-		})
-		err := authorizeTargets(context.Background(), cs.AuthorizationV1().SubjectAccessReviews(), nil, nil)
-		if err == nil {
-			t.Fatal("expected error for nil user")
-		}
-		if !strings.Contains(err.Error(), "no user") {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("empty targets is a no-op", func(t *testing.T) {
-		cs, seen := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
-			t.Fatal("SAR should not be called when targets is empty")
-			return nil, nil
-		})
-		err := authorizeTargets(context.Background(), cs.AuthorizationV1().SubjectAccessReviews(), userInfo, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(seen()) != 0 {
-			t.Fatalf("expected zero SARs, got %d", len(seen()))
-		}
-	})
-
-	t.Run("single allowed target", func(t *testing.T) {
-		cs, seen := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
-			sar.Status.Allowed = true
-			return sar, nil
-		})
-		err := authorizeTargets(
-			context.Background(),
-			cs.AuthorizationV1().SubjectAccessReviews(),
-			userInfo,
-			[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
-		)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		all := seen()
-		if len(all) != 1 {
-			t.Fatalf("expected 1 SAR, got %d", len(all))
-		}
-		sar := all[0]
-		if sar.Spec.User != "alice" || sar.Spec.UID != "uid-1" {
-			t.Fatalf("user/uid mismatch: %+v", sar.Spec)
-		}
-		if sar.Spec.ResourceAttributes == nil {
-			t.Fatal("ResourceAttributes nil")
-		}
-		ra := sar.Spec.ResourceAttributes
-		if ra.Group != "resourcemanager.miloapis.com" || ra.Version != "v1alpha1" ||
-			ra.Resource != "projects" || ra.Verb != "list" || ra.Namespace != "" {
-			t.Fatalf("ResourceAttributes mismatch: %+v", ra)
-		}
-		if got := sar.Spec.Extra["iam.miloapis.com/parent-type"]; len(got) != 1 || got[0] != "Project" {
-			t.Fatalf("Extra parent-type not propagated: %+v", sar.Spec.Extra)
-		}
-		if got := sar.Spec.Extra["iam.miloapis.com/parent-name"]; len(got) != 1 || got[0] != "acme-prod" {
-			t.Fatalf("Extra parent-name not propagated: %+v", sar.Spec.Extra)
-		}
-	})
-
-	t.Run("single denied target returns 403", func(t *testing.T) {
-		cs, _ := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
-			sar.Status.Allowed = false
-			sar.Status.Reason = "user not bound to project"
-			return sar, nil
-		})
-		err := authorizeTargets(
-			context.Background(),
-			cs.AuthorizationV1().SubjectAccessReviews(),
-			userInfo,
-			[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
-		)
-		if err == nil {
-			t.Fatal("expected error for denied SAR")
-		}
-		if !apierrors.IsForbidden(err) {
-			t.Fatalf("expected Forbidden, got %v", err)
-		}
-		if !strings.Contains(err.Error(), "user not bound to project") {
-			t.Fatalf("error should cite reason: %v", err)
-		}
-	})
-
-	t.Run("multi-target allow-all", func(t *testing.T) {
-		cs, seen := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
-			sar.Status.Allowed = true
-			return sar, nil
-		})
-		err := authorizeTargets(
-			context.Background(),
-			cs.AuthorizationV1().SubjectAccessReviews(),
-			userInfo,
-			[]searchv1alpha1.TargetResource{
-				target("resourcemanager.miloapis.com", "v1alpha1", "Project"),
-				target("networking.miloapis.com", "v1alpha1", "Domain"),
-				target("networking.miloapis.com", "v1alpha1", "DNSZone"),
-			},
-		)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got := len(seen()); got != 3 {
-			t.Fatalf("expected 3 SARs, got %d", got)
-		}
-	})
-
-	t.Run("multi-target second-denied short-circuits", func(t *testing.T) {
-		seenCalls := 0
-		cs, _ := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
-			seenCalls++
-			if seenCalls == 1 {
-				sar.Status.Allowed = true
-				return sar, nil
-			}
-			sar.Status.Allowed = false
-			sar.Status.Reason = "forbidden"
-			return sar, nil
-		})
-		err := authorizeTargets(
-			context.Background(),
-			cs.AuthorizationV1().SubjectAccessReviews(),
-			userInfo,
-			[]searchv1alpha1.TargetResource{
-				target("resourcemanager.miloapis.com", "v1alpha1", "Project"),
-				target("networking.miloapis.com", "v1alpha1", "Domain"),
-				target("networking.miloapis.com", "v1alpha1", "DNSZone"),
-			},
-		)
-		if err == nil {
-			t.Fatal("expected error on second denial")
-		}
-		if !apierrors.IsForbidden(err) {
-			t.Fatalf("expected Forbidden, got %v", err)
-		}
-		if seenCalls != 2 {
-			t.Fatalf("expected short-circuit after 2 calls, got %d", seenCalls)
-		}
-	})
-
-	t.Run("SAR API error wraps and bubbles", func(t *testing.T) {
-		cs, _ := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
-			return nil, errors.New("network is unreachable")
-		})
-		err := authorizeTargets(
-			context.Background(),
-			cs.AuthorizationV1().SubjectAccessReviews(),
-			userInfo,
-			[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
-		)
-		if err == nil {
-			t.Fatal("expected error from SAR API failure")
-		}
-		if apierrors.IsForbidden(err) {
-			t.Fatalf("API failure should not be 403, got %v", err)
-		}
-		if !strings.Contains(err.Error(), "network is unreachable") {
-			t.Fatalf("error should wrap cause: %v", err)
-		}
-	})
+var allKnown = fakePlurals{
+	gkProject: "projects",
+	gkDomain:  "domains",
 }
 
-func TestPluralForKind(t *testing.T) {
-	tests := []struct {
-		kind string
-		want string
-	}{
-		{"Project", "projects"},
-		{"Domain", "domains"},
-		{"DNSZone", "dnszones"},
-		{"Contact", "contacts"},
-		{"Organization", "organizations"},
+func TestAuthorizeTargets_NilUser_ReturnsError(t *testing.T) {
+	cs, _ := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+		t.Fatal("SAR should not be called when user is nil")
+		return nil, nil
+	})
+	err := authorizeTargets(
+		context.Background(),
+		cs.AuthorizationV1().SubjectAccessReviews(),
+		allKnown,
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for nil user")
 	}
-	for _, tt := range tests {
-		t.Run(tt.kind, func(t *testing.T) {
-			if got := pluralForKind(tt.kind); got != tt.want {
-				t.Fatalf("pluralForKind(%q) = %q, want %q", tt.kind, got, tt.want)
-			}
-		})
+	if !strings.Contains(err.Error(), "no user") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAuthorizeTargets_EmptyTargets_NoOp(t *testing.T) {
+	cs, seen := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+		t.Fatal("SAR should not be called when targets is empty")
+		return nil, nil
+	})
+	userInfo := &user.DefaultInfo{Name: "alice"}
+	err := authorizeTargets(
+		context.Background(),
+		cs.AuthorizationV1().SubjectAccessReviews(),
+		allKnown,
+		userInfo,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(seen()) != 0 {
+		t.Fatalf("expected zero SARs, got %d", len(seen()))
+	}
+}
+
+func TestAuthorizeTargets_SingleAllowed_PluralPassedToSAR(t *testing.T) {
+	cs, seen := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+		sar.Status.Allowed = true
+		return sar, nil
+	})
+	userInfo := &user.DefaultInfo{Name: "alice", UID: "uid-1", Groups: []string{"sg"}}
+	err := authorizeTargets(
+		context.Background(),
+		cs.AuthorizationV1().SubjectAccessReviews(),
+		allKnown,
+		userInfo,
+		[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	all := seen()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 SAR, got %d", len(all))
+	}
+	ra := all[0].Spec.ResourceAttributes
+	if ra.Resource != "projects" {
+		t.Fatalf("ResourceAttributes.Resource: got %q, want %q (plural from cache)", ra.Resource, "projects")
+	}
+	if ra.Verb != "list" {
+		t.Fatalf("verb: got %q, want \"list\"", ra.Verb)
+	}
+}
+
+func TestAuthorizeTargets_SingleDenied_ForbiddenWithPlural(t *testing.T) {
+	cs, _ := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+		sar.Status.Allowed = false
+		sar.Status.Reason = "test denial"
+		return sar, nil
+	})
+	userInfo := &user.DefaultInfo{Name: "alice"}
+	err := authorizeTargets(
+		context.Background(),
+		cs.AuthorizationV1().SubjectAccessReviews(),
+		allKnown,
+		userInfo,
+		[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
+	)
+	if err == nil {
+		t.Fatal("expected error for denied SAR")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("expected Forbidden, got %v", err)
+	}
+	// The error message should contain the plural form: "projects.resourcemanager.miloapis.com"
+	if !strings.Contains(err.Error(), "projects.resourcemanager.miloapis.com") {
+		t.Fatalf("error should mention plural 'projects.resourcemanager.miloapis.com', got: %v", err)
+	}
+}
+
+func TestAuthorizeTargets_UnknownKind_403WithoutSAR(t *testing.T) {
+	cs, seen := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+		t.Fatal("SAR should not be called when kind is unknown to the plural cache")
+		return nil, nil
+	})
+	emptyPlurals := fakePlurals{}
+	userInfo := &user.DefaultInfo{Name: "alice"}
+	err := authorizeTargets(
+		context.Background(),
+		cs.AuthorizationV1().SubjectAccessReviews(),
+		emptyPlurals,
+		userInfo,
+		[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
+	)
+	if err == nil {
+		t.Fatal("expected error for unknown kind")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("expected Forbidden for unknown kind, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "unknown resource kind") {
+		t.Fatalf("error should mention 'unknown resource kind', got: %v", err)
+	}
+	if len(seen()) != 0 {
+		t.Fatalf("SAR should not be created for unknown kind; got %d SARs", len(seen()))
+	}
+}
+
+func TestAuthorizeTargets_MultiTarget_UnknownInPositionTwo_ShortCircuits(t *testing.T) {
+	cs, seen := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+		sar.Status.Allowed = true
+		return sar, nil
+	})
+	// Project is known, but Widget is not.
+	plurals := fakePlurals{gkProject: "projects"}
+	userInfo := &user.DefaultInfo{Name: "alice"}
+	err := authorizeTargets(
+		context.Background(),
+		cs.AuthorizationV1().SubjectAccessReviews(),
+		plurals,
+		userInfo,
+		[]searchv1alpha1.TargetResource{
+			target("resourcemanager.miloapis.com", "v1alpha1", "Project"),
+			target("g.example.com", "v1alpha1", "Widget"),
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error for unknown second target")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("expected Forbidden, got %v", err)
+	}
+	if len(seen()) != 1 {
+		t.Fatalf("expected exactly 1 SAR (for target 1, then short-circuit on target 2); got %d", len(seen()))
+	}
+}
+
+func TestAuthorizeTargets_SARAPIError_Wrapped(t *testing.T) {
+	cs, _ := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+		return nil, errors.New("network is unreachable")
+	})
+	userInfo := &user.DefaultInfo{Name: "alice"}
+	err := authorizeTargets(
+		context.Background(),
+		cs.AuthorizationV1().SubjectAccessReviews(),
+		allKnown,
+		userInfo,
+		[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
+	)
+	if err == nil {
+		t.Fatal("expected error from SAR API failure")
+	}
+	if apierrors.IsForbidden(err) {
+		t.Fatalf("API failure should not be 403, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "network is unreachable") {
+		t.Fatalf("error should wrap cause, got: %v", err)
+	}
+}
+
+func TestAuthorizeTargets_ExtraPropagatedToSAR(t *testing.T) {
+	cs, seen := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+		sar.Status.Allowed = true
+		return sar, nil
+	})
+	userInfo := &user.DefaultInfo{
+		Name: "alice",
+		Extra: map[string][]string{
+			"iam.miloapis.com/parent-type": {"Project"},
+			"iam.miloapis.com/parent-name": {"acme"},
+		},
+	}
+	err := authorizeTargets(
+		context.Background(),
+		cs.AuthorizationV1().SubjectAccessReviews(),
+		allKnown,
+		userInfo,
+		[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	all := seen()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 SAR, got %d", len(all))
+	}
+	got := all[0].Spec.Extra["iam.miloapis.com/parent-type"]
+	if len(got) != 1 || got[0] != "Project" {
+		t.Fatalf("parent-type extra not propagated: got %+v", got)
 	}
 }

--- a/internal/registry/resourcesearchquery/authz_test.go
+++ b/internal/registry/resourcesearchquery/authz_test.go
@@ -1,0 +1,241 @@
+package resourcesearchquery
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	authzv1 "k8s.io/api/authorization/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	searchv1alpha1 "go.miloapis.net/search/pkg/apis/search/v1alpha1"
+)
+
+// fakeSARClient returns a SubjectAccessReviewInterface that calls the supplied
+// handler for every Create. Captures every SAR seen for assertions.
+func fakeSARClient(t *testing.T, handle func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error)) (
+	*fake.Clientset,
+	func() []*authzv1.SubjectAccessReview,
+) {
+	t.Helper()
+	cs := fake.NewSimpleClientset()
+	var seen []*authzv1.SubjectAccessReview
+	cs.PrependReactor("create", "subjectaccessreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		create := action.(clienttesting.CreateAction)
+		sar := create.GetObject().(*authzv1.SubjectAccessReview)
+		seen = append(seen, sar.DeepCopy())
+		resp, err := handle(sar)
+		if resp == nil {
+			resp = sar
+		}
+		return true, resp, err
+	})
+	return cs, func() []*authzv1.SubjectAccessReview { return seen }
+}
+
+func target(group, version, kind string) searchv1alpha1.TargetResource {
+	return searchv1alpha1.TargetResource{Group: group, Version: version, Kind: kind}
+}
+
+func TestAuthorizeTargets(t *testing.T) {
+	userInfo := &user.DefaultInfo{
+		Name:   "alice",
+		UID:    "uid-1",
+		Groups: []string{"system:authenticated", "tenants:acme"},
+		Extra: map[string][]string{
+			"iam.miloapis.com/parent-type": {"Project"},
+			"iam.miloapis.com/parent-name": {"acme-prod"},
+		},
+	}
+
+	t.Run("nil user returns error", func(t *testing.T) {
+		cs, _ := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+			t.Fatal("SAR should not be called when user is nil")
+			return nil, nil
+		})
+		err := authorizeTargets(context.Background(), cs.AuthorizationV1().SubjectAccessReviews(), nil, nil)
+		if err == nil {
+			t.Fatal("expected error for nil user")
+		}
+		if !strings.Contains(err.Error(), "no user") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty targets is a no-op", func(t *testing.T) {
+		cs, seen := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+			t.Fatal("SAR should not be called when targets is empty")
+			return nil, nil
+		})
+		err := authorizeTargets(context.Background(), cs.AuthorizationV1().SubjectAccessReviews(), userInfo, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(seen()) != 0 {
+			t.Fatalf("expected zero SARs, got %d", len(seen()))
+		}
+	})
+
+	t.Run("single allowed target", func(t *testing.T) {
+		cs, seen := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+			sar.Status.Allowed = true
+			return sar, nil
+		})
+		err := authorizeTargets(
+			context.Background(),
+			cs.AuthorizationV1().SubjectAccessReviews(),
+			userInfo,
+			[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		all := seen()
+		if len(all) != 1 {
+			t.Fatalf("expected 1 SAR, got %d", len(all))
+		}
+		sar := all[0]
+		if sar.Spec.User != "alice" || sar.Spec.UID != "uid-1" {
+			t.Fatalf("user/uid mismatch: %+v", sar.Spec)
+		}
+		if sar.Spec.ResourceAttributes == nil {
+			t.Fatal("ResourceAttributes nil")
+		}
+		ra := sar.Spec.ResourceAttributes
+		if ra.Group != "resourcemanager.miloapis.com" || ra.Version != "v1alpha1" ||
+			ra.Resource != "projects" || ra.Verb != "list" || ra.Namespace != "" {
+			t.Fatalf("ResourceAttributes mismatch: %+v", ra)
+		}
+		if got := sar.Spec.Extra["iam.miloapis.com/parent-type"]; len(got) != 1 || got[0] != "Project" {
+			t.Fatalf("Extra parent-type not propagated: %+v", sar.Spec.Extra)
+		}
+		if got := sar.Spec.Extra["iam.miloapis.com/parent-name"]; len(got) != 1 || got[0] != "acme-prod" {
+			t.Fatalf("Extra parent-name not propagated: %+v", sar.Spec.Extra)
+		}
+	})
+
+	t.Run("single denied target returns 403", func(t *testing.T) {
+		cs, _ := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+			sar.Status.Allowed = false
+			sar.Status.Reason = "user not bound to project"
+			return sar, nil
+		})
+		err := authorizeTargets(
+			context.Background(),
+			cs.AuthorizationV1().SubjectAccessReviews(),
+			userInfo,
+			[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
+		)
+		if err == nil {
+			t.Fatal("expected error for denied SAR")
+		}
+		if !apierrors.IsForbidden(err) {
+			t.Fatalf("expected Forbidden, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "user not bound to project") {
+			t.Fatalf("error should cite reason: %v", err)
+		}
+	})
+
+	t.Run("multi-target allow-all", func(t *testing.T) {
+		cs, seen := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+			sar.Status.Allowed = true
+			return sar, nil
+		})
+		err := authorizeTargets(
+			context.Background(),
+			cs.AuthorizationV1().SubjectAccessReviews(),
+			userInfo,
+			[]searchv1alpha1.TargetResource{
+				target("resourcemanager.miloapis.com", "v1alpha1", "Project"),
+				target("networking.miloapis.com", "v1alpha1", "Domain"),
+				target("networking.miloapis.com", "v1alpha1", "DNSZone"),
+			},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := len(seen()); got != 3 {
+			t.Fatalf("expected 3 SARs, got %d", got)
+		}
+	})
+
+	t.Run("multi-target second-denied short-circuits", func(t *testing.T) {
+		seenCalls := 0
+		cs, _ := fakeSARClient(t, func(sar *authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+			seenCalls++
+			if seenCalls == 1 {
+				sar.Status.Allowed = true
+				return sar, nil
+			}
+			sar.Status.Allowed = false
+			sar.Status.Reason = "forbidden"
+			return sar, nil
+		})
+		err := authorizeTargets(
+			context.Background(),
+			cs.AuthorizationV1().SubjectAccessReviews(),
+			userInfo,
+			[]searchv1alpha1.TargetResource{
+				target("resourcemanager.miloapis.com", "v1alpha1", "Project"),
+				target("networking.miloapis.com", "v1alpha1", "Domain"),
+				target("networking.miloapis.com", "v1alpha1", "DNSZone"),
+			},
+		)
+		if err == nil {
+			t.Fatal("expected error on second denial")
+		}
+		if !apierrors.IsForbidden(err) {
+			t.Fatalf("expected Forbidden, got %v", err)
+		}
+		if seenCalls != 2 {
+			t.Fatalf("expected short-circuit after 2 calls, got %d", seenCalls)
+		}
+	})
+
+	t.Run("SAR API error wraps and bubbles", func(t *testing.T) {
+		cs, _ := fakeSARClient(t, func(*authzv1.SubjectAccessReview) (*authzv1.SubjectAccessReview, error) {
+			return nil, errors.New("network is unreachable")
+		})
+		err := authorizeTargets(
+			context.Background(),
+			cs.AuthorizationV1().SubjectAccessReviews(),
+			userInfo,
+			[]searchv1alpha1.TargetResource{target("resourcemanager.miloapis.com", "v1alpha1", "Project")},
+		)
+		if err == nil {
+			t.Fatal("expected error from SAR API failure")
+		}
+		if apierrors.IsForbidden(err) {
+			t.Fatalf("API failure should not be 403, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "network is unreachable") {
+			t.Fatalf("error should wrap cause: %v", err)
+		}
+	})
+}
+
+func TestPluralForKind(t *testing.T) {
+	tests := []struct {
+		kind string
+		want string
+	}{
+		{"Project", "projects"},
+		{"Domain", "domains"},
+		{"DNSZone", "dnszones"},
+		{"Contact", "contacts"},
+		{"Organization", "organizations"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			if got := pluralForKind(tt.kind); got != tt.want {
+				t.Fatalf("pluralForKind(%q) = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/registry/resourcesearchquery/context.go
+++ b/internal/registry/resourcesearchquery/context.go
@@ -1,0 +1,52 @@
+package resourcesearchquery
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// Canonical extra keys that Milo's URL-pattern middleware sets when a request
+// comes in on a tenant-scoped URL (e.g. /apis/.../projects/<name>/control-plane/...).
+const (
+	parentTypeKey = "iam.miloapis.com/parent-type"
+	parentNameKey = "iam.miloapis.com/parent-name"
+)
+
+// parentContext captures the (type, name) pair that scopes a request to a
+// single tenant. nil means "no scope" — handlers should treat that as
+// preserving unscoped behavior, not as an error.
+type parentContext struct {
+	Type string
+	Name string
+}
+
+// extractParentContext returns a parentContext when BOTH parent-type and
+// parent-name are present and non-empty in user.Info.Extra. Multi-valued
+// keys take the first value (in practice these are single-valued).
+// Returns nil when either key is absent or empty, including when u is nil.
+func extractParentContext(u user.Info) *parentContext {
+	if u == nil {
+		return nil
+	}
+	extra := u.GetExtra()
+	types, hasType := extra[parentTypeKey]
+	names, hasName := extra[parentNameKey]
+	if !hasType || !hasName || len(types) == 0 || len(names) == 0 {
+		return nil
+	}
+	return &parentContext{Type: types[0], Name: names[0]}
+}
+
+// buildScopedFilter formats a Meilisearch filter clause that restricts results
+// to a single tenant. Returns "" when p is nil (no scoping). Uses %q quoting
+// to handle names containing quotes or backslashes safely. Type is lowercased
+// because stored _tenant_type values are conventionally lowercase.
+func buildScopedFilter(p *parentContext) string {
+	if p == nil {
+		return ""
+	}
+	return fmt.Sprintf(`(_tenant_type = %q AND _tenant = %q)`,
+		strings.ToLower(p.Type), p.Name)
+}

--- a/internal/registry/resourcesearchquery/context_test.go
+++ b/internal/registry/resourcesearchquery/context_test.go
@@ -1,0 +1,152 @@
+package resourcesearchquery
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestExtractParentContext(t *testing.T) {
+	tests := []struct {
+		name string
+		u    user.Info
+		want *parentContext
+	}{
+		{
+			name: "nil user returns nil",
+			u:    nil,
+			want: nil,
+		},
+		{
+			name: "both keys present returns context",
+			u: &user.DefaultInfo{
+				Name: "alice",
+				Extra: map[string][]string{
+					"iam.miloapis.com/parent-type": {"Project"},
+					"iam.miloapis.com/parent-name": {"acme-prod"},
+				},
+			},
+			want: &parentContext{Type: "Project", Name: "acme-prod"},
+		},
+		{
+			name: "only type present returns nil",
+			u: &user.DefaultInfo{
+				Extra: map[string][]string{
+					"iam.miloapis.com/parent-type": {"Project"},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "only name present returns nil",
+			u: &user.DefaultInfo{
+				Extra: map[string][]string{
+					"iam.miloapis.com/parent-name": {"acme-prod"},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "empty type slice returns nil",
+			u: &user.DefaultInfo{
+				Extra: map[string][]string{
+					"iam.miloapis.com/parent-type": {},
+					"iam.miloapis.com/parent-name": {"acme-prod"},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "empty name slice returns nil",
+			u: &user.DefaultInfo{
+				Extra: map[string][]string{
+					"iam.miloapis.com/parent-type": {"Project"},
+					"iam.miloapis.com/parent-name": {},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "no extras at all returns nil",
+			u:    &user.DefaultInfo{Name: "alice"},
+			want: nil,
+		},
+		{
+			name: "multi-valued keys take first value",
+			u: &user.DefaultInfo{
+				Extra: map[string][]string{
+					"iam.miloapis.com/parent-type": {"Organization", "Project"},
+					"iam.miloapis.com/parent-name": {"primary", "secondary"},
+				},
+			},
+			want: &parentContext{Type: "Organization", Name: "primary"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractParentContext(tt.u)
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("nilness mismatch: got %#v want %#v", got, tt.want)
+			}
+			if got != nil && (got.Type != tt.want.Type || got.Name != tt.want.Name) {
+				t.Fatalf("got %#v want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildScopedFilter(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *parentContext
+		want string
+	}{
+		{
+			name: "nil context returns empty filter",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "Project context lowercases type",
+			in:   &parentContext{Type: "Project", Name: "acme-prod"},
+			want: `(_tenant_type = "project" AND _tenant = "acme-prod")`,
+		},
+		{
+			name: "Organization context",
+			in:   &parentContext{Type: "Organization", Name: "datum"},
+			want: `(_tenant_type = "organization" AND _tenant = "datum")`,
+		},
+		{
+			name: "mixed-case type is lowercased",
+			in:   &parentContext{Type: "ProJECT", Name: "p1"},
+			want: `(_tenant_type = "project" AND _tenant = "p1")`,
+		},
+		{
+			name: "name with double quote is escaped",
+			in:   &parentContext{Type: "Project", Name: `evil"name`},
+			want: `(_tenant_type = "project" AND _tenant = "evil\"name")`,
+		},
+		{
+			name: "name with backslash is escaped",
+			in:   &parentContext{Type: "Project", Name: `back\slash`},
+			want: `(_tenant_type = "project" AND _tenant = "back\\slash")`,
+		},
+		{
+			name: "non-ASCII name is preserved literally",
+			in:   &parentContext{Type: "Project", Name: "café"},
+			want: `(_tenant_type = "project" AND _tenant = "café")`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildScopedFilter(tt.in)
+			if got != tt.want {
+				t.Fatalf("got %q want %q", got, tt.want)
+			}
+			if got != "" && (!strings.HasPrefix(got, "(") || !strings.HasSuffix(got, ")")) {
+				t.Fatalf("filter not wrapped in parens: %q", got)
+			}
+		})
+	}
+}

--- a/internal/registry/resourcesearchquery/rest.go
+++ b/internal/registry/resourcesearchquery/rest.go
@@ -9,24 +9,42 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	meiliapi "github.com/meilisearch/meilisearch-go"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	typedauthzv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/klog/v2"
 
-	"go.miloapis.net/search/internal/indexer"
+	policyevaluation "go.miloapis.net/search/internal/policy/evaluation"
 	searchv1alpha1 "go.miloapis.net/search/pkg/apis/search/v1alpha1"
 	"go.miloapis.net/search/pkg/meilisearch"
 )
 
+// multiSearcher is the subset of meilisearch.SDKClient that the REST handler
+// uses. Declaring it here lets tests substitute a fake without touching the
+// SDK client itself.
+type multiSearcher interface {
+	MultiSearch(indexUIDs []string, query string, limit, offset int64, filter string) (*meiliapi.MultiSearchResponse, error)
+}
+
+// policyLister is the subset of indexer.PolicyCache that the REST handler
+// uses. Declaring it here lets tests substitute a fake without a real
+// controller-runtime cache.
+type policyLister interface {
+	GetPolicies() []*policyevaluation.CachedPolicy
+}
+
 // REST implements a RESTStorage for ResourceSearchQuery API.
 type REST struct {
-	meiliClient        *meilisearch.SDKClient
-	policyCache        *indexer.PolicyCache
+	meiliClient        multiSearcher
+	policyCache        policyLister
+	sarClient          typedauthzv1.SubjectAccessReviewInterface
 	maxSearchLimit     int
 	defaultSearchLimit int
 	secretKey          []byte
@@ -40,10 +58,19 @@ var _ rest.Scoper = &REST{}
 var _ rest.SingularNameProvider = &REST{}
 
 // NewREST returns a RESTStorage object that will work against ResourceSearchQuery.
-func NewREST(meiliClient *meilisearch.SDKClient, policyCache *indexer.PolicyCache, maxSearchLimit int, defaultSearchLimit int, pagingSecret []byte, pagingTimeout time.Duration) *REST {
+func NewREST(
+	meiliClient *meilisearch.SDKClient,
+	policyCache policyLister,
+	sarClient typedauthzv1.SubjectAccessReviewInterface,
+	maxSearchLimit int,
+	defaultSearchLimit int,
+	pagingSecret []byte,
+	pagingTimeout time.Duration,
+) *REST {
 	return &REST{
 		meiliClient:        meiliClient,
 		policyCache:        policyCache,
+		sarClient:          sarClient,
 		maxSearchLimit:     maxSearchLimit,
 		defaultSearchLimit: defaultSearchLimit,
 		secretKey:          pagingSecret,
@@ -87,44 +114,75 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return nil, err
 	}
 
+	// Identity
+	userInfo, _ := request.UserFrom(ctx)
+	if userInfo == nil {
+		return nil, apierrors.NewUnauthorized("missing user in request context")
+	}
+
+	// Authorization
+	if err := authorizeTargets(ctx, r.sarClient, userInfo, query.Spec.TargetResources); err != nil {
+		return nil, err
+	}
+
 	indexUIDs, err := r.resolveIndexUIDs(query)
 	if err != nil {
 		return nil, err
 	}
-
 	if len(indexUIDs) == 0 {
-		// No ready policies or matching indices exist yet
-		created := query.DeepCopy()
-		created.Status = searchv1alpha1.ResourceSearchQueryStatus{
-			Results: []searchv1alpha1.SearchResult{},
-		}
-		return created, nil
+		return emptyQueryResult(query), nil
 	}
 
-	// Perform the multi search
-	resp, err := r.meiliClient.MultiSearch(indexUIDs, query.Spec.Query, limit, offset, "")
+	// Filter
+	parent := extractParentContext(userInfo)
+	filter := buildScopedFilter(parent)
+	if filter != "" {
+		klog.V(2).Infof("ResourceSearchQuery applying tenant scope filter type=%q name=%q across %d indices",
+			parent.Type, parent.Name, len(indexUIDs))
+	}
+
+	// Dispatch
+	resp, err := r.meiliClient.MultiSearch(indexUIDs, query.Spec.Query, limit, offset, filter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search: %w", err)
 	}
 
-	// Process search results
 	var results []searchv1alpha1.SearchResult
-
-	// Handle search results
 	for _, hit := range resp.Hits {
-		if res, err := formatSearchResult(hit); err == nil {
-			results = append(results, res)
+		res, err := formatSearchResult(hit)
+		if err != nil {
+			klog.Warningf("dropping Meilisearch hit due to format error: %v (hit keys: %v)", err, hitKeys(hit))
+			continue
 		}
+		results = append(results, res)
 	}
 
-	// Populate response status
 	created := query.DeepCopy()
 	created.Status = searchv1alpha1.ResourceSearchQueryStatus{
 		Results:  results,
 		Continue: r.calculateNextContinueToken(offset, limit, len(resp.Hits), query),
 	}
-
 	return created, nil
+}
+
+// emptyQueryResult returns a query result with an empty results list. Used
+// when no ready indices match the requested target resources.
+func emptyQueryResult(query *searchv1alpha1.ResourceSearchQuery) *searchv1alpha1.ResourceSearchQuery {
+	created := query.DeepCopy()
+	created.Status = searchv1alpha1.ResourceSearchQueryStatus{
+		Results: []searchv1alpha1.SearchResult{},
+	}
+	return created
+}
+
+// hitKeys returns the keys present in a Meilisearch hit for use in log
+// messages. Cheap — does not copy values.
+func hitKeys(hit map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(hit))
+	for k := range hit {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 type PagingClaims struct {

--- a/internal/registry/resourcesearchquery/rest.go
+++ b/internal/registry/resourcesearchquery/rest.go
@@ -21,6 +21,7 @@ import (
 	typedauthzv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/klog/v2"
 
+	"go.miloapis.net/search/internal/indexer"
 	policyevaluation "go.miloapis.net/search/internal/policy/evaluation"
 	searchv1alpha1 "go.miloapis.net/search/pkg/apis/search/v1alpha1"
 	"go.miloapis.net/search/pkg/meilisearch"
@@ -44,6 +45,7 @@ type policyLister interface {
 type REST struct {
 	meiliClient        multiSearcher
 	policyCache        policyLister
+	pluralCache        pluralLookup
 	sarClient          typedauthzv1.SubjectAccessReviewInterface
 	maxSearchLimit     int
 	defaultSearchLimit int
@@ -60,7 +62,8 @@ var _ rest.SingularNameProvider = &REST{}
 // NewREST returns a RESTStorage object that will work against ResourceSearchQuery.
 func NewREST(
 	meiliClient *meilisearch.SDKClient,
-	policyCache policyLister,
+	policyCache *indexer.PolicyCache,
+	pluralCache *indexer.FallbackPluralLookup,
 	sarClient typedauthzv1.SubjectAccessReviewInterface,
 	maxSearchLimit int,
 	defaultSearchLimit int,
@@ -70,6 +73,7 @@ func NewREST(
 	return &REST{
 		meiliClient:        meiliClient,
 		policyCache:        policyCache,
+		pluralCache:        pluralCache,
 		sarClient:          sarClient,
 		maxSearchLimit:     maxSearchLimit,
 		defaultSearchLimit: defaultSearchLimit,
@@ -121,7 +125,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	}
 
 	// Authorization
-	if err := authorizeTargets(ctx, r.sarClient, userInfo, query.Spec.TargetResources); err != nil {
+	if err := authorizeTargets(ctx, r.sarClient, r.pluralCache, userInfo, query.Spec.TargetResources); err != nil {
 		return nil, err
 	}
 

--- a/internal/registry/resourcesearchquery/rest.go
+++ b/internal/registry/resourcesearchquery/rest.go
@@ -102,7 +102,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	}
 
 	// Perform the multi search
-	resp, err := r.meiliClient.MultiSearch(indexUIDs, query.Spec.Query, limit, offset)
+	resp, err := r.meiliClient.MultiSearch(indexUIDs, query.Spec.Query, limit, offset, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to search: %w", err)
 	}

--- a/internal/registry/resourcesearchquery/rest_test.go
+++ b/internal/registry/resourcesearchquery/rest_test.go
@@ -1,0 +1,373 @@
+package resourcesearchquery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	meiliapi "github.com/meilisearch/meilisearch-go"
+	authzv1 "k8s.io/api/authorization/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	policyevaluation "go.miloapis.net/search/internal/policy/evaluation"
+	searchv1alpha1 "go.miloapis.net/search/pkg/apis/search/v1alpha1"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes shared across REST handler tests
+// ---------------------------------------------------------------------------
+
+// fakeMeiliClient is a test double for the multiSearcher interface.
+type fakeMeiliClient struct {
+	calls      int
+	lastUIDs   []string
+	lastQuery  string
+	lastLimit  int64
+	lastOffset int64
+	lastFilter string
+	resp       *meiliapi.MultiSearchResponse
+}
+
+func newFakeMeili() *fakeMeiliClient {
+	return &fakeMeiliClient{resp: &meiliapi.MultiSearchResponse{}}
+}
+
+func (f *fakeMeiliClient) MultiSearch(uids []string, q string, limit, offset int64, filter string) (*meiliapi.MultiSearchResponse, error) {
+	f.calls++
+	f.lastUIDs = uids
+	f.lastQuery = q
+	f.lastLimit = limit
+	f.lastOffset = offset
+	f.lastFilter = filter
+	return f.resp, nil
+}
+
+// newSARFake returns a fake Clientset whose SAR reactor either allows or denies
+// every SubjectAccessReview. Named differently from fakeSARClient in authz_test.go
+// (which captures per-call state); this simpler helper is sufficient for REST
+// handler integration tests.
+func newSARFake(t *testing.T, allow bool) *fake.Clientset {
+	t.Helper()
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "subjectaccessreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		sar := action.(clienttesting.CreateAction).GetObject().(*authzv1.SubjectAccessReview)
+		sar.Status.Allowed = allow
+		if !allow {
+			sar.Status.Reason = "test denial"
+		}
+		return true, sar, nil
+	})
+	return cs
+}
+
+// ctxWithUser wraps a user.Info into a context the way the API server does.
+func ctxWithUser(u user.Info) context.Context {
+	return apirequest.WithUser(context.Background(), u)
+}
+
+// ---------------------------------------------------------------------------
+// Fake policyLister
+// ---------------------------------------------------------------------------
+
+// fakePolicyLister implements policyLister with a fixed slice of policies.
+type fakePolicyLister struct {
+	policies []*policyevaluation.CachedPolicy
+}
+
+func (f *fakePolicyLister) GetPolicies() []*policyevaluation.CachedPolicy {
+	return f.policies
+}
+
+// newPolicyListerWithIndex builds a fakePolicyLister that exposes a single
+// ready policy whose target matches group/version/kind and whose index name
+// is indexName.
+func newPolicyListerWithIndex(group, version, kind, indexName string) *fakePolicyLister {
+	return &fakePolicyLister{
+		policies: []*policyevaluation.CachedPolicy{
+			{
+				Policy: &searchv1alpha1.ResourceIndexPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+					Spec: searchv1alpha1.ResourceIndexPolicySpec{
+						TargetResource: searchv1alpha1.TargetResource{
+							Group:   group,
+							Version: version,
+							Kind:    kind,
+						},
+					},
+					Status: searchv1alpha1.ResourceIndexPolicyStatus{
+						IndexName: indexName,
+					},
+				},
+			},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared test REST constructor
+// ---------------------------------------------------------------------------
+
+// newTestREST builds a *REST suitable for unit tests using the supplied fakes.
+func newTestREST(
+	t *testing.T,
+	meili multiSearcher,
+	policies policyLister,
+	sarCs *fake.Clientset,
+) *REST {
+	t.Helper()
+	return &REST{
+		meiliClient:        meili,
+		policyCache:        policies,
+		sarClient:          sarCs.AuthorizationV1().SubjectAccessReviews(),
+		maxSearchLimit:     100,
+		defaultSearchLimit: 10,
+		secretKey:          []byte("test-secret"),
+		pagingTimeout:      24 * time.Hour,
+	}
+}
+
+// testQuery builds a minimal ResourceSearchQuery with a single TargetResource
+// so that authorizeTargets and resolveIndexUIDs both have something to act on.
+func testQuery(group, version, kind string) *searchv1alpha1.ResourceSearchQuery {
+	return &searchv1alpha1.ResourceSearchQuery{
+		Spec: searchv1alpha1.ResourceSearchQuerySpec{
+			Query: "test",
+			TargetResources: []searchv1alpha1.TargetResource{
+				{Group: group, Version: version, Kind: kind},
+			},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCreate_NoUserReturns401
+// ---------------------------------------------------------------------------
+
+func TestCreate_NoUserReturns401(t *testing.T) {
+	const (
+		group   = "resourcemanager.miloapis.com"
+		version = "v1alpha1"
+		kind    = "Project"
+		index   = "projects-idx"
+	)
+
+	meili := newFakeMeili()
+	sars := newSARFake(t, true)
+	r := newTestREST(t, meili, newPolicyListerWithIndex(group, version, kind, index), sars)
+	q := testQuery(group, version, kind)
+
+	// context.Background() has no user — Create must return 401.
+	_, err := r.Create(context.Background(), q, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing user")
+	}
+	if !apierrors.IsUnauthorized(err) {
+		t.Fatalf("expected Unauthorized, got %v", err)
+	}
+	// Meilisearch must not be contacted before identity is established.
+	if meili.calls != 0 {
+		t.Fatalf("Meilisearch should not be called; calls=%d", meili.calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCreate_NoParentContext_PassesEmptyFilter
+// ---------------------------------------------------------------------------
+
+func TestCreate_NoParentContext_PassesEmptyFilter(t *testing.T) {
+	const (
+		group   = "resourcemanager.miloapis.com"
+		version = "v1alpha1"
+		kind    = "Project"
+		index   = "projects-idx"
+	)
+
+	meili := newFakeMeili()
+	sars := newSARFake(t, true)
+	r := newTestREST(t, meili, newPolicyListerWithIndex(group, version, kind, index), sars)
+	q := testQuery(group, version, kind)
+
+	// User has no parent-type / parent-name extras — filter must be empty.
+	u := &user.DefaultInfo{Name: "alice", Groups: []string{"system:authenticated"}}
+	_, err := r.Create(ctxWithUser(u), q, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meili.calls != 1 {
+		t.Fatalf("expected 1 Meilisearch call, got %d", meili.calls)
+	}
+	if meili.lastFilter != "" {
+		t.Fatalf("expected empty filter, got %q", meili.lastFilter)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCreate_WithParentContext_AppliesScopedFilter
+// ---------------------------------------------------------------------------
+
+func TestCreate_WithParentContext_AppliesScopedFilter(t *testing.T) {
+	const (
+		group   = "resourcemanager.miloapis.com"
+		version = "v1alpha1"
+		kind    = "Project"
+		index   = "projects-idx"
+	)
+
+	meili := newFakeMeili()
+	sars := newSARFake(t, true)
+	r := newTestREST(t, meili, newPolicyListerWithIndex(group, version, kind, index), sars)
+	q := testQuery(group, version, kind)
+
+	u := &user.DefaultInfo{
+		Name: "alice",
+		Extra: map[string][]string{
+			"iam.miloapis.com/parent-type": {"Project"},
+			"iam.miloapis.com/parent-name": {"acme-prod"},
+		},
+	}
+	_, err := r.Create(ctxWithUser(u), q, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := `(_tenant_type = "project" AND _tenant = "acme-prod")`
+	if meili.lastFilter != want {
+		t.Fatalf("filter = %q, want %q", meili.lastFilter, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCreate_SARDenied_Returns403NoMeili
+// ---------------------------------------------------------------------------
+
+func TestCreate_SARDenied_Returns403NoMeili(t *testing.T) {
+	const (
+		group   = "resourcemanager.miloapis.com"
+		version = "v1alpha1"
+		kind    = "Project"
+		index   = "projects-idx"
+	)
+
+	meili := newFakeMeili()
+	sars := newSARFake(t, false) // deny all
+	r := newTestREST(t, meili, newPolicyListerWithIndex(group, version, kind, index), sars)
+	q := testQuery(group, version, kind)
+
+	u := &user.DefaultInfo{Name: "alice"}
+	_, err := r.Create(ctxWithUser(u), q, nil, nil)
+	if err == nil {
+		t.Fatal("expected error from SAR denial")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("expected Forbidden, got %v", err)
+	}
+	// Meilisearch must not be contacted when authorization fails.
+	if meili.calls != 0 {
+		t.Fatalf("Meilisearch should not be called on SAR denial; calls=%d", meili.calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCreate_EmptyTargets_NoSARNoFilter
+// ---------------------------------------------------------------------------
+
+// When TargetResources is empty, authorizeTargets is a no-op and
+// resolveIndexUIDs returns all ready policies. With no parent context the
+// filter must be empty.
+func TestCreate_EmptyTargets_NoSARNoFilter(t *testing.T) {
+	meili := newFakeMeili()
+	sars := newSARFake(t, true)
+	policies := newPolicyListerWithIndex("a.example.com", "v1", "Foo", "foo-idx")
+	r := newTestREST(t, meili, policies, sars)
+
+	q := &searchv1alpha1.ResourceSearchQuery{
+		Spec: searchv1alpha1.ResourceSearchQuerySpec{Query: "hello"},
+	}
+	u := &user.DefaultInfo{Name: "alice"}
+	_, err := r.Create(ctxWithUser(u), q, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meili.calls != 1 {
+		t.Fatalf("expected 1 Meilisearch call, got %d", meili.calls)
+	}
+	if meili.lastFilter != "" {
+		t.Fatalf("expected empty filter for unscoped user, got %q", meili.lastFilter)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCreate_NoPolicies_ReturnsEmpty
+// ---------------------------------------------------------------------------
+
+// When there are no ready policies resolveIndexUIDs returns an empty slice
+// and Create short-circuits with an empty result (no Meilisearch call).
+func TestCreate_NoPolicies_ReturnsEmpty(t *testing.T) {
+	meili := newFakeMeili()
+	sars := newSARFake(t, true)
+	r := newTestREST(t, meili, &fakePolicyLister{}, sars)
+
+	q := &searchv1alpha1.ResourceSearchQuery{
+		Spec: searchv1alpha1.ResourceSearchQuerySpec{Query: "hello"},
+	}
+	u := &user.DefaultInfo{Name: "alice"}
+	out, err := r.Create(ctxWithUser(u), q, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result, ok := out.(*searchv1alpha1.ResourceSearchQuery)
+	if !ok {
+		t.Fatalf("expected *ResourceSearchQuery, got %T", out)
+	}
+	if len(result.Status.Results) != 0 {
+		t.Fatalf("expected empty results, got %d", len(result.Status.Results))
+	}
+	if meili.calls != 0 {
+		t.Fatalf("Meilisearch should not be called when no policies exist; calls=%d", meili.calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCreate_PaginationValidation
+// ---------------------------------------------------------------------------
+
+func TestCreate_PaginationValidation(t *testing.T) {
+	sars := newSARFake(t, true)
+	policies := &fakePolicyLister{}
+	u := &user.DefaultInfo{Name: "alice"}
+
+	t.Run("negative limit returns 400", func(t *testing.T) {
+		meili := newFakeMeili()
+		r := newTestREST(t, meili, policies, sars)
+		q := &searchv1alpha1.ResourceSearchQuery{
+			Spec: searchv1alpha1.ResourceSearchQuerySpec{Query: "x", Limit: -1},
+		}
+		_, err := r.Create(ctxWithUser(u), q, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for negative limit")
+		}
+		if !apierrors.IsBadRequest(err) {
+			t.Fatalf("expected BadRequest, got %v", err)
+		}
+	})
+
+	t.Run("limit exceeding max returns 400", func(t *testing.T) {
+		meili := newFakeMeili()
+		r := newTestREST(t, meili, policies, sars)
+		q := &searchv1alpha1.ResourceSearchQuery{
+			Spec: searchv1alpha1.ResourceSearchQuerySpec{Query: "x", Limit: 200},
+		}
+		_, err := r.Create(ctxWithUser(u), q, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for limit exceeding max")
+		}
+		if !apierrors.IsBadRequest(err) {
+			t.Fatalf("expected BadRequest, got %v", err)
+		}
+	})
+}

--- a/internal/registry/resourcesearchquery/rest_test.go
+++ b/internal/registry/resourcesearchquery/rest_test.go
@@ -113,6 +113,12 @@ func newPolicyListerWithIndex(group, version, kind, indexName string) *fakePolic
 // Shared test REST constructor
 // ---------------------------------------------------------------------------
 
+// testPlurals is the default plural map for REST handler tests. It covers the
+// Project kind used by newTestProjectQuery / testQuery helpers.
+var testPlurals = fakePlurals{
+	{Group: "resourcemanager.miloapis.com", Kind: "Project"}: "projects",
+}
+
 // newTestREST builds a *REST suitable for unit tests using the supplied fakes.
 func newTestREST(
 	t *testing.T,
@@ -124,12 +130,19 @@ func newTestREST(
 	return &REST{
 		meiliClient:        meili,
 		policyCache:        policies,
+		pluralCache:        testPlurals,
 		sarClient:          sarCs.AuthorizationV1().SubjectAccessReviews(),
 		maxSearchLimit:     100,
 		defaultSearchLimit: 10,
 		secretKey:          []byte("test-secret"),
 		pagingTimeout:      24 * time.Hour,
 	}
+}
+
+// newTestProjectQuery builds a minimal ResourceSearchQuery targeting the Project
+// kind, used by tests that need a non-empty TargetResources list.
+func newTestProjectQuery() *searchv1alpha1.ResourceSearchQuery {
+	return testQuery("resourcemanager.miloapis.com", "v1alpha1", "Project")
 }
 
 // testQuery builds a minimal ResourceSearchQuery with a single TargetResource
@@ -370,4 +383,39 @@ func TestCreate_PaginationValidation(t *testing.T) {
 			t.Fatalf("expected BadRequest, got %v", err)
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// TestCreate_UnknownKind_Returns403WithoutMeili
+// ---------------------------------------------------------------------------
+
+// When the requested Kind is not in the plural cache, authorizeTargets cannot
+// construct a SAR ResourceAttributes and must return Forbidden. Meilisearch
+// must never be contacted.
+func TestCreate_UnknownKind_Returns403WithoutMeili(t *testing.T) {
+	sars := newSARFake(t, true) // allow-all; must not be reached
+	meili := newFakeMeili()
+	// Empty plurals map — Project kind is unknown to authz.
+	r := &REST{
+		meiliClient:        meili,
+		policyCache:        newPolicyListerWithIndex("resourcemanager.miloapis.com", "v1alpha1", "Project", "projects-idx"),
+		pluralCache:        fakePlurals{},
+		sarClient:          sars.AuthorizationV1().SubjectAccessReviews(),
+		maxSearchLimit:     100,
+		defaultSearchLimit: 10,
+		secretKey:          []byte("test-secret"),
+		pagingTimeout:      0,
+	}
+
+	u := &user.DefaultInfo{Name: "alice"}
+	_, err := r.Create(ctxWithUser(u), newTestProjectQuery(), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown kind")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("expected Forbidden, got %v", err)
+	}
+	if meili.calls != 0 {
+		t.Fatalf("Meilisearch should not be called on unknown-kind 403; calls=%d", meili.calls)
+	}
 }

--- a/pkg/meilisearch/sdk_client.go
+++ b/pkg/meilisearch/sdk_client.go
@@ -473,18 +473,29 @@ func (s *SDKClient) GetSettingsUpdateTask(indexUID string) (*meilisearch.Task, e
 }
 
 // MultiSearch performs a search query across multiple indices.
-func (s *SDKClient) MultiSearch(indexUIDs []string, query string, limit int64, offset int64) (*meilisearch.MultiSearchResponse, error) {
+// If filter is non-empty, it's applied identically to every per-index query
+// as a Meilisearch filter expression. Pass "" to skip filtering.
+func (s *SDKClient) MultiSearch(
+	indexUIDs []string,
+	query string,
+	limit, offset int64,
+	filter string,
+) (*meilisearch.MultiSearchResponse, error) {
 	if len(indexUIDs) == 0 {
 		return nil, fmt.Errorf("no index UIDs provided")
 	}
 
-	var queries []*meilisearch.SearchRequest
+	queries := make([]*meilisearch.SearchRequest, 0, len(indexUIDs))
 	for _, uid := range indexUIDs {
-		queries = append(queries, &meilisearch.SearchRequest{
+		req := &meilisearch.SearchRequest{
 			IndexUID:         uid,
 			Query:            query,
 			ShowRankingScore: true,
-		})
+		}
+		if filter != "" {
+			req.Filter = filter
+		}
+		queries = append(queries, req)
 	}
 
 	req := &meilisearch.MultiSearchRequest{
@@ -495,12 +506,12 @@ func (s *SDKClient) MultiSearch(indexUIDs []string, query string, limit int64, o
 		},
 	}
 
-	klog.V(4).Infof("MultiSearch across indices %v with query %q, limit %d, offset %d", indexUIDs, query, limit, offset)
+	klog.V(6).Infof("MultiSearch across indices %v with query %q, limit %d, offset %d, filter %q",
+		indexUIDs, query, limit, offset, filter)
 	resp, err := s.client.MultiSearch(req)
 	if err != nil {
-		klog.Errorf("MultiSearch failed across indices %v: %v", indexUIDs, err)
+		klog.Errorf("MultiSearch failed across indices %v with filter %q: %v", indexUIDs, filter, err)
 		return nil, fmt.Errorf("multi-search failed: %w", err)
 	}
-
 	return resp, nil
 }

--- a/test/e2e/search-flow-tenant-scope/chainsaw-test.yaml
+++ b/test/e2e/search-flow-tenant-scope/chainsaw-test.yaml
@@ -1,0 +1,392 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: search-flow-tenant-scope
+spec:
+  description: |
+    Exercises the tenant-scoped search feature end-to-end against the live cluster.
+    Six documents are seeded into Meilisearch via NATS ReindexEvents — two each
+    under tenants p-one (project), p-two (project), and acme (organization).
+
+    Three behavioral paths are validated:
+      - T1: Unscoped query (no impersonation) — all 6 docs returned (staff-portal
+            behavior preserved; no filter applied to Meilisearch).
+      - T2: Scoped query (--as=alice --as-extra=parent-type=Project
+            --as-extra=parent-name=p-one) — only the two p-one docs returned;
+            p-two and acme docs are filtered out by Meilisearch.
+      - T3: Scoped query targeting a kind alice has no list rights on (Domain) —
+            the SAR returns denied; the handler returns 403 before ever calling
+            Meilisearch.
+
+  namespace: default
+
+  steps:
+    # =========================================================================
+    # Pre-cleanup: idempotent teardown of any leftover resources
+    # =========================================================================
+    - name: pre-cleanup
+      description: "Removes leftover resources to ensure idempotent test execution"
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              kubectl delete resourceindexpolicy e2e-tenant-scope-project-policy --ignore-not-found=true || true
+              kubectl delete job e2e-ts-nats-publisher --ignore-not-found=true || true
+              kubectl delete job e2e-ts-t2-impersonator -n search-system --ignore-not-found=true || true
+              kubectl delete job e2e-ts-t3-denial -n search-system --ignore-not-found=true || true
+              kubectl delete configmap e2e-ts-nats-events --ignore-not-found=true || true
+              kubectl delete clusterrolebinding search-tenant-scope-impersonator search-tenant-scope-reader-alice --ignore-not-found=true || true
+              kubectl delete clusterrole search-tenant-scope-impersonator search-tenant-scope-reader --ignore-not-found=true || true
+              kubectl delete serviceaccount search-tenant-scope-tester -n search-system --ignore-not-found=true || true
+              sleep 5
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # Step 1: Apply RBAC — impersonation rights + alice's Project list grant
+    # =========================================================================
+    - name: setup-rbac
+      description: "Creates ServiceAccount, impersonation ClusterRole/Binding, and alice's reader role"
+      try:
+        - apply:
+            file: rbac.yaml
+
+    # =========================================================================
+    # Step 2: Apply seed policy (ResourceIndexPolicy for Projects)
+    # =========================================================================
+    - name: apply-seed-policy
+      description: "Creates the ResourceIndexPolicy targeting resourcemanager.miloapis.com/Project"
+      try:
+        - apply:
+            file: seed.yaml
+
+    # =========================================================================
+    # Step 3: Wait for the seed policy to reach Ready=True
+    # =========================================================================
+    - name: wait-for-seed-policy-ready
+      description: "Waits for the Project policy to reach Ready=True before seeding documents"
+      try:
+        - wait:
+            apiVersion: search.miloapis.com/v1alpha1
+            kind: ResourceIndexPolicy
+            name: e2e-tenant-scope-project-policy
+            timeout: 60s
+            for:
+              condition:
+                name: Ready
+                value: "True"
+
+    # =========================================================================
+    # Step 4: Publish 6 ReindexEvents via NATS — two docs per tenant
+    #
+    # Tenant layout:
+    #   _tenant=p-one,   _tenant_type=project      → t1-a, t1-b
+    #   _tenant=p-two,   _tenant_type=project      → t2-a, t2-b
+    #   _tenant=acme,    _tenant_type=organization → t3-a, t3-b
+    #
+    # The index name is computed by GetSearchIndex:
+    #   resourcemanager-miloapis-com_v1alpha1_Project
+    #
+    # SpecHash is intentionally omitted so the consumer skips the hash check.
+    # =========================================================================
+    - name: publish-reindex-events
+      description: "Publishes 6 ReindexEvents to NATS covering three tenant/type combinations"
+      try:
+        - script:
+            timeout: 120s
+            content: |
+              INDEX_NAME=$(kubectl get resourceindexpolicy e2e-tenant-scope-project-policy -o jsonpath='{.status.indexName}')
+              if [ -z "$INDEX_NAME" ]; then
+                echo "ERROR: indexName is empty on policy status"
+                exit 1
+              fi
+              echo "Using indexName: $INDEX_NAME"
+
+              # Build 6 event payloads with INDEX_NAME substituted.
+              # Each event carries tenant/tenantType so the reindex consumer stores
+              # _tenant and _tenant_type on the indexed document.
+              DOC1=$(printf \
+                '{"id":"e2e-ts-t1-a-uid","policyName":"e2e-tenant-scope-project-policy","indexName":"%s","tenant":"p-one","tenantType":"project","resource":{"apiVersion":"resourcemanager.miloapis.com/v1alpha1","kind":"Project","metadata":{"name":"t1-a","uid":"e2e-ts-t1-a-uid","annotations":{"e2e.search.test/marker":"tenant-scope-e2e-rn1"}}}}' \
+                "$INDEX_NAME")
+
+              DOC2=$(printf \
+                '{"id":"e2e-ts-t1-b-uid","policyName":"e2e-tenant-scope-project-policy","indexName":"%s","tenant":"p-one","tenantType":"project","resource":{"apiVersion":"resourcemanager.miloapis.com/v1alpha1","kind":"Project","metadata":{"name":"t1-b","uid":"e2e-ts-t1-b-uid","annotations":{"e2e.search.test/marker":"tenant-scope-e2e-rn1"}}}}' \
+                "$INDEX_NAME")
+
+              DOC3=$(printf \
+                '{"id":"e2e-ts-t2-a-uid","policyName":"e2e-tenant-scope-project-policy","indexName":"%s","tenant":"p-two","tenantType":"project","resource":{"apiVersion":"resourcemanager.miloapis.com/v1alpha1","kind":"Project","metadata":{"name":"t2-a","uid":"e2e-ts-t2-a-uid","annotations":{"e2e.search.test/marker":"tenant-scope-e2e-rn1"}}}}' \
+                "$INDEX_NAME")
+
+              DOC4=$(printf \
+                '{"id":"e2e-ts-t2-b-uid","policyName":"e2e-tenant-scope-project-policy","indexName":"%s","tenant":"p-two","tenantType":"project","resource":{"apiVersion":"resourcemanager.miloapis.com/v1alpha1","kind":"Project","metadata":{"name":"t2-b","uid":"e2e-ts-t2-b-uid","annotations":{"e2e.search.test/marker":"tenant-scope-e2e-rn1"}}}}' \
+                "$INDEX_NAME")
+
+              DOC5=$(printf \
+                '{"id":"e2e-ts-t3-a-uid","policyName":"e2e-tenant-scope-project-policy","indexName":"%s","tenant":"acme","tenantType":"organization","resource":{"apiVersion":"resourcemanager.miloapis.com/v1alpha1","kind":"Project","metadata":{"name":"t3-a","uid":"e2e-ts-t3-a-uid","annotations":{"e2e.search.test/marker":"tenant-scope-e2e-rn1"}}}}' \
+                "$INDEX_NAME")
+
+              DOC6=$(printf \
+                '{"id":"e2e-ts-t3-b-uid","policyName":"e2e-tenant-scope-project-policy","indexName":"%s","tenant":"acme","tenantType":"organization","resource":{"apiVersion":"resourcemanager.miloapis.com/v1alpha1","kind":"Project","metadata":{"name":"t3-b","uid":"e2e-ts-t3-b-uid","annotations":{"e2e.search.test/marker":"tenant-scope-e2e-rn1"}}}}' \
+                "$INDEX_NAME")
+
+              # Store payloads in a ConfigMap so they can be mounted into the Job
+              # container without shell escaping issues.
+              kubectl delete configmap e2e-ts-nats-events --ignore-not-found=true || true
+              kubectl create configmap e2e-ts-nats-events \
+                --from-literal=doc1="$DOC1" \
+                --from-literal=doc2="$DOC2" \
+                --from-literal=doc3="$DOC3" \
+                --from-literal=doc4="$DOC4" \
+                --from-literal=doc5="$DOC5" \
+                --from-literal=doc6="$DOC6"
+
+              # Job reads each file from the ConfigMap volume and publishes sequentially.
+              # <<'JOBEOF' (quoted heredoc) prevents the outer shell from expanding
+              # $(cat /events/doc1) — the $() is evaluated inside the container.
+              cat <<'JOBEOF' | kubectl apply -f -
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: e2e-ts-nats-publisher
+                namespace: default
+              spec:
+                ttlSecondsAfterFinished: 120
+                template:
+                  spec:
+                    restartPolicy: Never
+                    volumes:
+                      - name: events
+                        configMap:
+                          name: e2e-ts-nats-events
+                    containers:
+                      - name: publisher
+                        image: natsio/nats-box:latest
+                        command:
+                          - /bin/sh
+                          - -c
+                          - |
+                            nats pub reindex.e2e.tenant-scope "$(cat /events/doc1)" --server nats://nats.nats-system.svc.cluster.local:4222 &&
+                            nats pub reindex.e2e.tenant-scope "$(cat /events/doc2)" --server nats://nats.nats-system.svc.cluster.local:4222 &&
+                            nats pub reindex.e2e.tenant-scope "$(cat /events/doc3)" --server nats://nats.nats-system.svc.cluster.local:4222 &&
+                            nats pub reindex.e2e.tenant-scope "$(cat /events/doc4)" --server nats://nats.nats-system.svc.cluster.local:4222 &&
+                            nats pub reindex.e2e.tenant-scope "$(cat /events/doc5)" --server nats://nats.nats-system.svc.cluster.local:4222 &&
+                            nats pub reindex.e2e.tenant-scope "$(cat /events/doc6)" --server nats://nats.nats-system.svc.cluster.local:4222
+                        volumeMounts:
+                          - name: events
+                            mountPath: /events
+              JOBEOF
+
+              kubectl wait job/e2e-ts-nats-publisher --for=condition=complete --timeout=60s
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # Step 5: Wait for indexing to propagate
+    # =========================================================================
+    - name: wait-for-indexing
+      description: "Waits 30 seconds for ReindexEvents to be processed and indexed by Meilisearch"
+      try:
+        - script:
+            timeout: 35s
+            content: sleep 30
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # T1: Unscoped query — all 6 docs returned (staff-portal behavior preserved)
+    #
+    # No --as impersonation. user.Info.Extra has no parent-* keys.
+    # buildScopedFilter returns "" → no filter sent to Meilisearch → all docs
+    # across all tenants are visible.
+    # =========================================================================
+    - name: T1-unscoped-query-returns-all-docs
+      description: "T1: Without impersonation, all 6 seeded docs must be returned"
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              RESULT=$(cat <<EOF | kubectl create -f - -o json
+              apiVersion: search.miloapis.com/v1alpha1
+              kind: ResourceSearchQuery
+              metadata:
+                name: t1-unscoped
+              spec:
+                targetResources:
+                  - group: "resourcemanager.miloapis.com"
+                    version: v1alpha1
+                    kind: Project
+                query: "tenant-scope-e2e-rn1"
+                limit: 50
+              EOF
+              )
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t1-a")] | length > 0' && \
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t1-b")] | length > 0' && \
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t2-a")] | length > 0' && \
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t2-b")] | length > 0' && \
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t3-a")] | length > 0' && \
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t3-b")] | length > 0'
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # T2: Scoped query — only the two p-one docs returned
+    #
+    # Impersonate alice with parent-type=Project + parent-name=p-one.
+    # buildScopedFilter produces: (_tenant_type = "project" AND _tenant = "p-one")
+    # Meilisearch applies that filter; only t1-a and t1-b match.
+    #
+    # kubectl 1.33 does not expose impersonation extras via a CLI flag, so we
+    # run the request from inside the cluster as a Job. The Pod uses the
+    # search-tenant-scope-tester ServiceAccount (which has impersonate RBAC on
+    # users/userextras) and curls the apiserver directly with Impersonate-User
+    # plus Impersonate-Extra-* headers (the latter URL-encode the slash in the
+    # extra key: iam.miloapis.com%2Fparent-type).
+    # =========================================================================
+    - name: T2-scoped-query-returns-only-tenant-docs
+      description: "T2: With parent-type=Project + parent-name=p-one, only the two p-one docs must be returned"
+      try:
+        - script:
+            timeout: 120s
+            content: |
+              kubectl delete job e2e-ts-t2-impersonator -n search-system --ignore-not-found=true || true
+              cat <<'JOBEOF' | kubectl apply -f -
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: e2e-ts-t2-impersonator
+                namespace: search-system
+              spec:
+                backoffLimit: 0
+                ttlSecondsAfterFinished: 120
+                template:
+                  spec:
+                    restartPolicy: Never
+                    serviceAccountName: search-tenant-scope-tester
+                    containers:
+                      - name: tester
+                        image: curlimages/curl:latest
+                        command:
+                          - /bin/sh
+                          - -c
+                          - |
+                            set -e
+                            TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                            CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                            BODY='{"apiVersion":"search.miloapis.com/v1alpha1","kind":"ResourceSearchQuery","metadata":{"name":"t2-scoped-p-one"},"spec":{"targetResources":[{"group":"resourcemanager.miloapis.com","version":"v1alpha1","kind":"Project"}],"query":"tenant-scope-e2e-rn1","limit":50}}'
+                            RESP=$(curl -sX POST https://kubernetes.default.svc/apis/search.miloapis.com/v1alpha1/resourcesearchqueries \
+                              --cacert "$CACERT" \
+                              -H "Authorization: Bearer $TOKEN" \
+                              -H "Content-Type: application/json" \
+                              -H "Accept: application/json" \
+                              -H "Impersonate-User: alice" \
+                              -H "Impersonate-Extra-iam.miloapis.com%2Fparent-type: Project" \
+                              -H "Impersonate-Extra-iam.miloapis.com%2Fparent-name: p-one" \
+                              -d "$BODY")
+                            echo "RESP: $RESP"
+                            echo "$RESP" | grep -q '"name": *"t1-a"' || { echo "FAIL: missing t1-a"; exit 1; }
+                            echo "$RESP" | grep -q '"name": *"t1-b"' || { echo "FAIL: missing t1-b"; exit 1; }
+                            if echo "$RESP" | grep -q '"name": *"t2-a"'; then echo "FAIL: t2-a should be filtered"; exit 1; fi
+                            if echo "$RESP" | grep -q '"name": *"t2-b"'; then echo "FAIL: t2-b should be filtered"; exit 1; fi
+                            if echo "$RESP" | grep -q '"name": *"t3-a"'; then echo "FAIL: t3-a should be filtered"; exit 1; fi
+                            if echo "$RESP" | grep -q '"name": *"t3-b"'; then echo "FAIL: t3-b should be filtered"; exit 1; fi
+                            echo "PASS"
+              JOBEOF
+              if ! kubectl wait job/e2e-ts-t2-impersonator -n search-system --for=condition=complete --timeout=90s 2>&1; then
+                echo "--- Job did not complete; dumping diagnostics ---"
+                kubectl get job e2e-ts-t2-impersonator -n search-system -o yaml || true
+                kubectl logs -n search-system job/e2e-ts-t2-impersonator --all-containers=true --tail=200 || true
+                exit 1
+              fi
+              kubectl logs -n search-system job/e2e-ts-t2-impersonator --all-containers=true --tail=200
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # T3: Unauthorized target → 403, no Meilisearch call
+    #
+    # alice has no list rights on networking.miloapis.com/Domain.
+    # authorizeTargets() issues a SAR which the k8s RBAC layer denies.
+    # The handler wraps the denial as apierrors.NewForbidden and returns it
+    # before resolveIndexUIDs or MultiSearch is ever called.
+    #
+    # Same Job+curl pattern as T2. We inspect the HTTP status code from curl
+    # (-w '%{http_code}') and assert it is exactly 403.
+    # =========================================================================
+    - name: T3-unauthorized-target-returns-403
+      description: "T3: Querying a kind alice cannot list must be rejected with 403 Forbidden"
+      try:
+        - script:
+            timeout: 120s
+            content: |
+              kubectl delete job e2e-ts-t3-denial -n search-system --ignore-not-found=true || true
+              cat <<'JOBEOF' | kubectl apply -f -
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: e2e-ts-t3-denial
+                namespace: search-system
+              spec:
+                backoffLimit: 0
+                ttlSecondsAfterFinished: 120
+                template:
+                  spec:
+                    restartPolicy: Never
+                    serviceAccountName: search-tenant-scope-tester
+                    containers:
+                      - name: tester
+                        image: curlimages/curl:latest
+                        command:
+                          - /bin/sh
+                          - -c
+                          - |
+                            set -e
+                            TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                            CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                            BODY='{"apiVersion":"search.miloapis.com/v1alpha1","kind":"ResourceSearchQuery","metadata":{"generateName":"t3-denied-"},"spec":{"targetResources":[{"group":"networking.miloapis.com","version":"v1alpha1","kind":"Domain"}],"query":"","limit":10}}'
+                            HTTP_CODE=$(curl -sX POST https://kubernetes.default.svc/apis/search.miloapis.com/v1alpha1/resourcesearchqueries \
+                              --cacert "$CACERT" \
+                              -H "Authorization: Bearer $TOKEN" \
+                              -H "Content-Type: application/json" \
+                              -H "Accept: application/json" \
+                              -H "Impersonate-User: alice" \
+                              -H "Impersonate-Extra-iam.miloapis.com%2Fparent-type: Project" \
+                              -H "Impersonate-Extra-iam.miloapis.com%2Fparent-name: p-one" \
+                              -d "$BODY" \
+                              -o /tmp/resp.json \
+                              -w "%{http_code}")
+                            echo "HTTP $HTTP_CODE"
+                            echo "BODY:"
+                            cat /tmp/resp.json
+                            if [ "$HTTP_CODE" != "403" ]; then echo "FAIL: expected 403, got $HTTP_CODE"; exit 1; fi
+                            grep -qi "forbidden" /tmp/resp.json || { echo "FAIL: response body did not mention forbidden"; exit 1; }
+                            echo "PASS"
+              JOBEOF
+              if ! kubectl wait job/e2e-ts-t3-denial -n search-system --for=condition=complete --timeout=90s 2>&1; then
+                echo "--- Job did not complete; dumping diagnostics ---"
+                kubectl get job e2e-ts-t3-denial -n search-system -o yaml || true
+                kubectl logs -n search-system job/e2e-ts-t3-denial --all-containers=true --tail=200 || true
+                exit 1
+              fi
+              kubectl logs -n search-system job/e2e-ts-t3-denial --all-containers=true --tail=200
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # Cleanup
+    # =========================================================================
+    - name: cleanup
+      description: "Removes all resources created by this test suite"
+      try:
+        - script:
+            timeout: 60s
+            content: |
+              kubectl delete job e2e-ts-nats-publisher --ignore-not-found=true || true
+              kubectl delete job e2e-ts-t2-impersonator -n search-system --ignore-not-found=true || true
+              kubectl delete job e2e-ts-t3-denial -n search-system --ignore-not-found=true || true
+              kubectl delete configmap e2e-ts-nats-events --ignore-not-found=true || true
+              kubectl delete resourceindexpolicy e2e-tenant-scope-project-policy --ignore-not-found=true || true
+              kubectl delete clusterrolebinding search-tenant-scope-impersonator search-tenant-scope-reader-alice --ignore-not-found=true || true
+              kubectl delete clusterrole search-tenant-scope-impersonator search-tenant-scope-reader --ignore-not-found=true || true
+              kubectl delete serviceaccount search-tenant-scope-tester -n search-system --ignore-not-found=true || true
+            check:
+              ($error): ~

--- a/test/e2e/search-flow-tenant-scope/chainsaw-test.yaml
+++ b/test/e2e/search-flow-tenant-scope/chainsaw-test.yaml
@@ -272,8 +272,9 @@ spec:
                             set -e
                             TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
                             CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                            BODY='{"apiVersion":"search.miloapis.com/v1alpha1","kind":"ResourceSearchQuery","metadata":{"name":"t2-scoped-p-one"},"spec":{"targetResources":[{"group":"resourcemanager.miloapis.com","version":"v1alpha1","kind":"Project"}],"query":"tenant-scope-e2e-rn1","limit":50}}'
-                            RESP=$(curl -sX POST https://kubernetes.default.svc/apis/search.miloapis.com/v1alpha1/resourcesearchqueries \
+                            # Job emits the JSON response to stdout.
+                            # Assertions happen in the outer chainsaw script where jq is available.
+                            curl -sX POST https://kubernetes.default.svc/apis/search.miloapis.com/v1alpha1/resourcesearchqueries \
                               --cacert "$CACERT" \
                               -H "Authorization: Bearer $TOKEN" \
                               -H "Content-Type: application/json" \
@@ -281,15 +282,7 @@ spec:
                               -H "Impersonate-User: alice" \
                               -H "Impersonate-Extra-iam.miloapis.com%2Fparent-type: Project" \
                               -H "Impersonate-Extra-iam.miloapis.com%2Fparent-name: p-one" \
-                              -d "$BODY")
-                            echo "RESP: $RESP"
-                            echo "$RESP" | grep -q '"name": *"t1-a"' || { echo "FAIL: missing t1-a"; exit 1; }
-                            echo "$RESP" | grep -q '"name": *"t1-b"' || { echo "FAIL: missing t1-b"; exit 1; }
-                            if echo "$RESP" | grep -q '"name": *"t2-a"'; then echo "FAIL: t2-a should be filtered"; exit 1; fi
-                            if echo "$RESP" | grep -q '"name": *"t2-b"'; then echo "FAIL: t2-b should be filtered"; exit 1; fi
-                            if echo "$RESP" | grep -q '"name": *"t3-a"'; then echo "FAIL: t3-a should be filtered"; exit 1; fi
-                            if echo "$RESP" | grep -q '"name": *"t3-b"'; then echo "FAIL: t3-b should be filtered"; exit 1; fi
-                            echo "PASS"
+                              -d '{"apiVersion":"search.miloapis.com/v1alpha1","kind":"ResourceSearchQuery","metadata":{"name":"t2-scoped-p-one"},"spec":{"targetResources":[{"group":"resourcemanager.miloapis.com","version":"v1alpha1","kind":"Project"}],"query":"tenant-scope-e2e-rn1","limit":50}}'
               JOBEOF
               if ! kubectl wait job/e2e-ts-t2-impersonator -n search-system --for=condition=complete --timeout=90s 2>&1; then
                 echo "--- Job did not complete; dumping diagnostics ---"
@@ -297,7 +290,14 @@ spec:
                 kubectl logs -n search-system job/e2e-ts-t2-impersonator --all-containers=true --tail=200 || true
                 exit 1
               fi
-              kubectl logs -n search-system job/e2e-ts-t2-impersonator --all-containers=true --tail=200
+              RESULT=$(kubectl logs -n search-system job/e2e-ts-t2-impersonator --all-containers=true --tail=-1)
+              echo "$RESULT"
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t1-a")] | length > 0'
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t1-b")] | length > 0'
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t2-a")] | length == 0'
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t2-b")] | length == 0'
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t3-a")] | length == 0'
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "t3-b")] | length == 0'
             check:
               ($error): ~
 
@@ -342,7 +342,6 @@ spec:
                             set -e
                             TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
                             CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                            BODY='{"apiVersion":"search.miloapis.com/v1alpha1","kind":"ResourceSearchQuery","metadata":{"generateName":"t3-denied-"},"spec":{"targetResources":[{"group":"networking.miloapis.com","version":"v1alpha1","kind":"Domain"}],"query":"","limit":10}}'
                             HTTP_CODE=$(curl -sX POST https://kubernetes.default.svc/apis/search.miloapis.com/v1alpha1/resourcesearchqueries \
                               --cacert "$CACERT" \
                               -H "Authorization: Bearer $TOKEN" \
@@ -351,15 +350,12 @@ spec:
                               -H "Impersonate-User: alice" \
                               -H "Impersonate-Extra-iam.miloapis.com%2Fparent-type: Project" \
                               -H "Impersonate-Extra-iam.miloapis.com%2Fparent-name: p-one" \
-                              -d "$BODY" \
+                              -d '{"apiVersion":"search.miloapis.com/v1alpha1","kind":"ResourceSearchQuery","metadata":{"generateName":"t3-denied-"},"spec":{"targetResources":[{"group":"networking.miloapis.com","version":"v1alpha1","kind":"Domain"}],"query":"","limit":10}}' \
                               -o /tmp/resp.json \
                               -w "%{http_code}")
                             echo "HTTP $HTTP_CODE"
                             echo "BODY:"
                             cat /tmp/resp.json
-                            if [ "$HTTP_CODE" != "403" ]; then echo "FAIL: expected 403, got $HTTP_CODE"; exit 1; fi
-                            grep -qi "forbidden" /tmp/resp.json || { echo "FAIL: response body did not mention forbidden"; exit 1; }
-                            echo "PASS"
               JOBEOF
               if ! kubectl wait job/e2e-ts-t3-denial -n search-system --for=condition=complete --timeout=90s 2>&1; then
                 echo "--- Job did not complete; dumping diagnostics ---"
@@ -367,7 +363,21 @@ spec:
                 kubectl logs -n search-system job/e2e-ts-t3-denial --all-containers=true --tail=200 || true
                 exit 1
               fi
-              kubectl logs -n search-system job/e2e-ts-t3-denial --all-containers=true --tail=200
+              LOG=$(kubectl logs -n search-system job/e2e-ts-t3-denial --all-containers=true --tail=-1)
+              echo "$LOG"
+              HTTP_CODE=$(echo "$LOG" | awk '/^HTTP / {print $2; exit}')
+              BODY=$(echo "$LOG" | awk 'f{print} /^BODY:/{f=1}')
+              test "$HTTP_CODE" = "403"
+              echo "$BODY" | jq -e '.reason == "Forbidden"'
+              echo "$BODY" | jq -e '.code == 403'
+              # K8s Status `.details.kind` surfaces the Resource field of the
+              # schema.GroupResource that NewForbidden was called with. Per
+              # milo-os convention (and Jose's review comment #3), we pass the
+              # lowercase plural here — "domains", not the singular Kind.
+              echo "$BODY" | jq -e '.details.kind == "domains"'
+              # And the human-readable message still cites the original Kind
+              # in its trailing "is not authorized to search .../Domain" phrase.
+              echo "$BODY" | jq -e '.message | test("Domain")'
             check:
               ($error): ~
 

--- a/test/e2e/search-flow-tenant-scope/rbac.yaml
+++ b/test/e2e/search-flow-tenant-scope/rbac.yaml
@@ -1,0 +1,69 @@
+---
+# ServiceAccount that the test pod/script runs as. Must be created before the
+# impersonator binding below so that the binding subject resolves correctly.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: search-tenant-scope-tester
+  namespace: search-system
+---
+# ClusterRole that grants impersonation of user "alice" and the
+# iam.miloapis.com/parent-* extra keys, plus create on ResourceSearchQuery.
+# Bound to the search-system ServiceAccount that chainsaw runs as.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: search-tenant-scope-impersonator
+rules:
+- apiGroups: [""]
+  resources: ["users", "groups", "serviceaccounts"]
+  verbs: ["impersonate"]
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+    - "userextras/iam.miloapis.com/parent-type"
+    - "userextras/iam.miloapis.com/parent-name"
+  verbs: ["impersonate"]
+- apiGroups: ["search.miloapis.com"]
+  resources: ["resourcesearchqueries"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: search-tenant-scope-impersonator
+subjects:
+- kind: ServiceAccount
+  name: search-tenant-scope-tester
+  namespace: search-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: search-tenant-scope-impersonator
+---
+# Grant "alice" list rights on Projects only.
+# Domain / networking.miloapis.com is intentionally NOT granted here so that
+# the SAR-denial scenario (T3) hits a real 403.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: search-tenant-scope-reader
+rules:
+- apiGroups: ["resourcemanager.miloapis.com"]
+  resources: ["projects"]
+  verbs: ["list"]
+- apiGroups: ["search.miloapis.com"]
+  resources: ["resourcesearchqueries"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: search-tenant-scope-reader-alice
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: alice
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: search-tenant-scope-reader

--- a/test/e2e/search-flow-tenant-scope/seed.yaml
+++ b/test/e2e/search-flow-tenant-scope/seed.yaml
@@ -1,0 +1,18 @@
+---
+# ResourceIndexPolicy targeting Projects so the REST handler's resolveIndexUIDs
+# can map targetResources[group=resourcemanager.miloapis.com, kind=Project] to
+# its Meilisearch index. No CEL conditions — all resources match (index-all path).
+apiVersion: search.miloapis.com/v1alpha1
+kind: ResourceIndexPolicy
+metadata:
+  name: e2e-tenant-scope-project-policy
+spec:
+  targetResource:
+    group: "resourcemanager.miloapis.com"
+    version: v1alpha1
+    kind: Project
+  fields:
+    - path: ".metadata.name"
+      searchable: true
+    - path: ".metadata.annotations['e2e.search.test/marker']"
+      searchable: true


### PR DESCRIPTION
## Summary

Makes `ResourceSearchQuery` tenant-context-aware **without adding any new fields on the request body**, in response to @scotwells's feedback in #87. When the request carries `iam.miloapis.com/parent-{type,name}` in `user.Info.Extra` (set by Milo's URL-pattern middleware on per-project URLs), the search filter is scoped to that single tenant. When the extras are absent, today's behavior is preserved — root-URL callers like the staff portal keep working unchanged.

Also adds a `SubjectAccessReview` (verb `list`) per `targetResource` before any search dispatch. Denial → 403, SAR API error → fail-closed 5xx. No Meilisearch call on denial.

## What changed from the original draft

This PR started as an explicit `spec.tenantScope` field. After feedback in #87 it was reshaped to read the tenant from `user.Info.Extra`.
## Files

- New: `internal/registry/resourcesearchquery/{context,authz}.go` (+ tests) — parent-context extraction, scoped filter, and SAR authorization
- Modified: `internal/registry/resourcesearchquery/rest.go` — `Create()` flow + new `sarClient` parameter on `NewREST`
- Modified: `pkg/meilisearch/sdk_client.go` — `MultiSearch` gains a `filter string` parameter
- Modified: `internal/apiserver/apiserver.go` + `cmd/search/main.go` — wire the SAR client (`rest.InClusterConfig`, NOT loopback) through `ExtraConfig`
- New: `test/e2e/search-flow-tenant-scope/` — chainsaw scenario via in-cluster `Impersonate-Extra-*` curl Jobs

## Caveats

Per-project URL routing for the search apiserver doesn't exist yet — that's platform plumbing in `milo-os/milo` / `milo-os/graphql-gateway`, out of scope here. Until it lands the scoped path is a no-op for normal callers; the change is forward-compatible and lights up automatically when the platform side catches up. Cross-tenant search for tenant users (cmd-K UX) is a separate future surface.

## Test plan

- [x] Unit + integration tests on the new helpers and `REST.Create` flow (mocked SAR + Meili)
- [x] Chainsaw e2e against KIND: unscoped → all docs, scoped → only that tenant's docs, unauthorized target → 403 with no Meili call
- [x] Backwards-compat: root-URL callers unchanged

Related: #87, #93.