### PR TITLE
feat: maintain full object in the index

### DIFF
--- a/internal/policy/evaluation/evaluator.go
+++ b/internal/policy/evaluation/evaluator.go
@@ -1,12 +1,12 @@
 package evaluation
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/google/cel-go/cel"
 	"go.miloapis.net/search/pkg/apis/search/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 )
 
@@ -14,8 +14,10 @@ import (
 type EvalResult struct {
 	// Matched is true if the resource satisfied any condition.
 	Matched bool
-	// Fields contains the extracted field values from the resource, keyed by path.
-	Fields map[string]any
+	// Object is the full source object from the matched resource (u.Object). It
+	// is populated only when Matched is true. Shared reference; Transform()
+	// deep-copies before any mutation.
+	Object map[string]any
 	// Group is the API group of the matching policy.
 	Group string
 	// Version is the API version of the matching policy.
@@ -42,11 +44,10 @@ type CachedPolicy struct {
 	Conditions map[string]cel.Program
 }
 
-// Evaluate checks if the resource matches the policy's target GVK, conditions,
-// and extracts the configured fields from matching resources.
+// Evaluate checks if the resource matches the policy's target GVK and conditions.
+// When matched, the full source object is stored on the result for use by Transform().
 func (cp *CachedPolicy) Evaluate(u *unstructured.Unstructured) (*EvalResult, error) {
 	result := &EvalResult{
-		Fields:  map[string]any{},
 		Group:   cp.Policy.Spec.TargetResource.Group,
 		Version: cp.Policy.Spec.TargetResource.Version,
 		Kind:    cp.Policy.Spec.TargetResource.Kind,
@@ -93,90 +94,46 @@ func (cp *CachedPolicy) Evaluate(u *unstructured.Unstructured) (*EvalResult, err
 		return result, nil
 	}
 
-	// 4. Extract fields from the matched resource using the path segments
-	for _, field := range cp.Policy.Spec.Fields {
-		segments := ParsePath(field.Path)
-		if len(segments) == 0 {
-			continue
-		}
-
-		var current any = u.Object
-		found := true
-		for _, key := range segments {
-			if m, ok := current.(map[string]any); ok {
-				if val, exists := m[key]; exists {
-					current = val
-					continue
-				}
-			}
-			// Handle array index access (e.g. "0" for [0])
-			if list, ok := current.([]any); ok {
-				if idx, err := strconv.Atoi(key); err == nil {
-					if idx >= 0 && idx < len(list) {
-						current = list[idx]
-						continue
-					}
-				}
-			}
-
-			found = false
-			break
-		}
-
-		if found {
-			result.Fields[field.Path] = current
-		}
-	}
+	// 4. Store the full source object so Transform() can build the complete document.
+	result.Object = u.Object
 
 	return result, nil
 }
 
 // Transform converts the evaluation result into a document for indexing.
-// It reconstructs the nested structure based on the field paths.
-// For example, ".metadata.name" -> {"metadata": {"name": "value"}}.
+// It deep-copies the full source object, strips managedFields, and overlays
+// policy-derived metadata (apiVersion, kind, _tenant, _tenant_type).
 func (r *EvalResult) Transform() map[string]any {
-	doc := make(map[string]any)
-
-	for path, value := range r.Fields {
-		segments := ParsePath(path)
-		if len(segments) == 0 {
-			continue
-		}
-
-		// Traverse and build structure
-		current := doc
-		for i := 0; i < len(segments)-1; i++ {
-			seg := segments[i]
-
-			// Check if key exists
-			v, exists := current[seg]
-			if !exists {
-				// Create new map
-				m := make(map[string]any)
-				current[seg] = m
-				current = m
-				continue
-			}
-
-			// If exists, checks if it is a map
-			if m, ok := v.(map[string]any); ok {
-				current = m
-			} else {
-				// Conflict: existing value is not a map (e.g. was a scalar).
-				// We overwrite it with a map to support the deeper path.
-				// This implies the deeper path takes precedence structurally.
-				m := make(map[string]any)
-				current[seg] = m
-				current = m
-			}
-		}
-
-		// Set leaf value
-		leaf := segments[len(segments)-1]
-		current[leaf] = value
+	// Deep-copy so we never mutate the shared source object.
+	doc := runtime.DeepCopyJSON(r.Object)
+	if doc == nil {
+		doc = make(map[string]any)
 	}
 
-	// Add policy GVK metadata to the document
+	// Strip metadata noise in a single type assertion.
+	if meta, ok := doc["metadata"].(map[string]any); ok {
+		// managedFields is verbose tracking data that is not useful for search.
+		delete(meta, "managedFields")
+
+		// Strip the last-applied-configuration annotation universally. This annotation
+		// can mirror unredacted Secret payloads when objects are managed via kubectl apply,
+		// making it the largest single field on most objects and a potential data-leak vector.
+		if annotations, ok := meta["annotations"].(map[string]any); ok {
+			delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
+			if len(annotations) == 0 {
+				delete(meta, "annotations")
+			}
+		}
+	}
+
+	// Strip Secret fields that contain sensitive data
+	if r.Group == "" && r.Version == "v1" && r.Kind == "Secret" {
+		delete(doc, "data")
+		delete(doc, "stringData")
+	}
+
+	// Overlay policy GVK metadata — these unconditionally win over any values
+	// the source object may have carried for the same keys.
 	if r.Group != "" {
 		doc["apiVersion"] = r.Group + "/" + r.Version
 	} else {

--- a/internal/policy/evaluation/evaluator_test.go
+++ b/internal/policy/evaluation/evaluator_test.go
@@ -130,11 +130,13 @@ func TestEvaluate(t *testing.T) {
 	require.NoError(t, err)
 
 	type testCase struct {
-		name           string
-		policy         *v1alpha1.ResourceIndexPolicy
-		resource       *unstructured.Unstructured
-		expectedMatch  bool
-		expectedFields map[string]any
+		name          string
+		policy        *v1alpha1.ResourceIndexPolicy
+		resource      *unstructured.Unstructured
+		expectedMatch bool
+		// expectedObject is only checked when expectedMatch is true. nil means
+		// "don't check the object contents" (e.g. conditions-only tests).
+		expectedObject map[string]any
 	}
 
 	// Helper to compile conditions
@@ -175,8 +177,7 @@ func TestEvaluate(t *testing.T) {
 					"kind":       "Service",
 				},
 			},
-			expectedMatch:  false,
-			expectedFields: map[string]any{},
+			expectedMatch: false,
 		},
 		{
 			name: "Match with simple condition",
@@ -206,8 +207,13 @@ func TestEvaluate(t *testing.T) {
 				},
 			},
 			expectedMatch: true,
-			expectedFields: map[string]any{
-				".metadata.name": "my-config",
+			expectedObject: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":   "my-config",
+					"labels": map[string]any{"env": "prod"},
+				},
 			},
 		},
 		{
@@ -234,8 +240,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			expectedMatch:  false,
-			expectedFields: map[string]any{},
+			expectedMatch: false,
 		},
 		{
 			name: "Match with multiple conditions (OR semantics) - first matches",
@@ -261,8 +266,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			expectedMatch:  true,
-			expectedFields: map[string]any{},
+			expectedMatch: true,
 		},
 		{
 			name: "Match with multiple conditions (OR semantics) - second matches",
@@ -288,11 +292,10 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			expectedMatch:  true,
-			expectedFields: map[string]any{},
+			expectedMatch: true,
 		},
 		{
-			name: "Field extraction with nested and missing fields",
+			name: "Full object stored on match (including non-policy fields)",
 			policy: &v1alpha1.ResourceIndexPolicy{
 				Spec: v1alpha1.ResourceIndexPolicySpec{
 					TargetResource: v1alpha1.TargetResource{
@@ -303,25 +306,19 @@ func TestEvaluate(t *testing.T) {
 					Conditions: []v1alpha1.PolicyCondition{
 						{Name: "all", Expression: "true"},
 					},
-					Fields: []v1alpha1.FieldPolicy{
-						{Path: ".spec.replicas"},
-						{Path: ".spec.template.spec.containers[0].image"},
-						{Path: ".status.availableReplicas"}, // Missing in resource
-					},
 				},
 			},
 			resource: &unstructured.Unstructured{
 				Object: map[string]any{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
+					"metadata": map[string]any{"name": "my-deploy", "namespace": "default"},
 					"spec": map[string]any{
 						"replicas": int64(3),
 						"template": map[string]any{
 							"spec": map[string]any{
 								"containers": []any{
-									map[string]any{
-										"image": "nginx:latest",
-									},
+									map[string]any{"image": "nginx:latest"},
 								},
 							},
 						},
@@ -329,9 +326,21 @@ func TestEvaluate(t *testing.T) {
 				},
 			},
 			expectedMatch: true,
-			expectedFields: map[string]any{
-				".spec.replicas": int64(3),
-				".spec.template.spec.containers[0].image": "nginx:latest",
+			// No Fields declared; full source object is stored regardless of declared field surface.
+			expectedObject: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]any{"name": "my-deploy", "namespace": "default"},
+				"spec": map[string]any{
+					"replicas": int64(3),
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{"image": "nginx:latest"},
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -362,8 +371,7 @@ func TestEvaluate(t *testing.T) {
 			// If spec is missing, activation won't have "spec".
 			// Expr "spec.restartPolicy" refers to variable "spec".
 			// Since "spec" is missing from activation, Eval will return error: "undeclared reference to 'spec'".
-			expectedMatch:  false,
-			expectedFields: map[string]any{},
+			expectedMatch: false,
 		},
 		{
 			name: "Multiple conditions (OR), none match",
@@ -383,60 +391,14 @@ func TestEvaluate(t *testing.T) {
 					"metadata":   map[string]any{"name": "my-pod"},
 				},
 			},
-			expectedMatch:  false,
-			expectedFields: map[string]any{},
+			expectedMatch: false,
 		},
 		{
-			name: "Complex nested array and map extraction",
+			name: "No conditions — unconditional match stores full object",
 			policy: &v1alpha1.ResourceIndexPolicy{
 				Spec: v1alpha1.ResourceIndexPolicySpec{
 					TargetResource: v1alpha1.TargetResource{Group: "", Version: "v1", Kind: "Pod"},
-					Conditions: []v1alpha1.PolicyCondition{
-						{Name: "all", Expression: "true"},
-					},
-					Fields: []v1alpha1.FieldPolicy{
-						{Path: ".spec.containers[1].ports[0].containerPort"},
-						{Path: ".spec.volumes[0].name"},
-					},
-				},
-			},
-			resource: &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "v1",
-					"kind":       "Pod",
-					"spec": map[string]any{
-						"containers": []any{
-							map[string]any{"name": "c1"}, // index 0
-							map[string]any{ // index 1
-								"name": "c2",
-								"ports": []any{
-									map[string]any{"containerPort": int64(8080)},
-								},
-							},
-						},
-						"volumes": []any{
-							map[string]any{"name": "vol1"},
-						},
-					},
-				},
-			},
-			expectedMatch: true,
-			expectedFields: map[string]any{
-				".spec.containers[1].ports[0].containerPort": int64(8080),
-				".spec.volumes[0].name":                      "vol1",
-			},
-		},
-		{
-			name: "Field extraction edge cases: index out of bounds, type mismatch",
-			policy: &v1alpha1.ResourceIndexPolicy{
-				Spec: v1alpha1.ResourceIndexPolicySpec{
-					TargetResource: v1alpha1.TargetResource{Group: "", Version: "v1", Kind: "Pod"},
-					Conditions:     []v1alpha1.PolicyCondition{{Name: "all", Expression: "true"}},
-					Fields: []v1alpha1.FieldPolicy{
-						{Path: ".spec.containers[99].name"}, // Index out of bounds
-						{Path: ".spec.containers.name"},     // Treating array as map
-						{Path: ".metadata.name[0]"},         // Treating string as array
-					},
+					// No Conditions
 				},
 			},
 			resource: &unstructured.Unstructured{
@@ -444,15 +406,16 @@ func TestEvaluate(t *testing.T) {
 					"apiVersion": "v1",
 					"kind":       "Pod",
 					"metadata":   map[string]any{"name": "my-pod"},
-					"spec": map[string]any{
-						"containers": []any{
-							map[string]any{"name": "c1"},
-						},
-					},
+					"spec":       map[string]any{"nodeName": "node-1"},
 				},
 			},
-			expectedMatch:  true,
-			expectedFields: map[string]any{}, // None should be extracted
+			expectedMatch: true,
+			expectedObject: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata":   map[string]any{"name": "my-pod"},
+				"spec":       map[string]any{"nodeName": "node-1"},
+			},
 		},
 	}
 
@@ -463,8 +426,18 @@ func TestEvaluate(t *testing.T) {
 			require.NoError(t, err) // Evaluate currently returns nil error always
 
 			assert.Equal(t, tt.expectedMatch, result.Matched, "Matched status mismatch")
-			if tt.expectedMatch {
-				assert.Equal(t, tt.expectedFields, result.Fields, "Fields mismatch")
+
+			if !tt.expectedMatch {
+				assert.Nil(t, result.Object, "Object should be nil when not matched")
+				return
+			}
+
+			// When matched: Object must be set
+			assert.NotNil(t, result.Object, "Object must be set when matched")
+
+			// When the test provides an expected object shape, verify it exactly
+			if tt.expectedObject != nil {
+				assert.Equal(t, tt.expectedObject, result.Object, "Object mismatch")
 			}
 		})
 	}

--- a/internal/policy/evaluation/transform_test.go
+++ b/internal/policy/evaluation/transform_test.go
@@ -1,27 +1,90 @@
 package evaluation
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEvalResult_Transform(t *testing.T) {
 	tests := []struct {
 		name     string
-		fields   map[string]any
-		group    string
-		version  string
-		kind     string
+		result   *EvalResult
 		expected map[string]any
 	}{
 		{
-			name:    "empty fields",
-			fields:  map[string]any{},
-			group:   "search.miloapis.com",
-			version: "v1alpha1",
-			kind:    "ResourceIndexPolicy",
+			name: "full object is included in output",
+			result: &EvalResult{
+				Matched: true,
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "my-config",
+						"namespace": "default",
+					},
+					// data is a non-policy field — must still appear in the doc
+					"data": map[string]any{
+						"key": "value",
+					},
+				},
+				Group:   "",
+				Version: "v1",
+				Kind:    "ConfigMap",
+			},
+			expected: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "my-config",
+					"namespace": "default",
+				},
+				"data":         map[string]any{"key": "value"},
+				"_tenant":      "platform",
+				"_tenant_type": "platform",
+			},
+		},
+		{
+			name: "managedFields is stripped from metadata",
+			result: &EvalResult{
+				Matched: true,
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]any{
+						"name": "my-deploy",
+						"managedFields": []any{
+							map[string]any{"manager": "kubectl", "operation": "Apply"},
+						},
+					},
+					"spec": map[string]any{"replicas": int64(1)},
+				},
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+			expected: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]any{"name": "my-deploy"},
+				"spec":       map[string]any{"replicas": int64(1)},
+				"_tenant":      "platform",
+				"_tenant_type": "platform",
+			},
+		},
+		{
+			name: "apiVersion overlay: group + version",
+			result: &EvalResult{
+				Matched: true,
+				Object: map[string]any{
+					"apiVersion": "old/v0", // will be overwritten
+					"kind":       "OldKind",
+				},
+				Group:   "search.miloapis.com",
+				Version: "v1alpha1",
+				Kind:    "ResourceIndexPolicy",
+			},
 			expected: map[string]any{
 				"apiVersion":   "search.miloapis.com/v1alpha1",
 				"kind":         "ResourceIndexPolicy",
@@ -30,294 +93,263 @@ func TestEvalResult_Transform(t *testing.T) {
 			},
 		},
 		{
-			name:    "single field",
-			fields:  map[string]any{".metadata.name": "test-cm"},
-			group:   "",
-			version: "v1",
-			kind:    "ConfigMap",
+			name: "apiVersion overlay: core group (empty group)",
+			result: &EvalResult{
+				Matched: true,
+				Object: map[string]any{
+					"apiVersion": "old/v0",
+					"kind":       "OldKind",
+				},
+				Group:   "",
+				Version: "v1",
+				Kind:    "Pod",
+			},
+			expected: map[string]any{
+				"apiVersion":   "v1",
+				"kind":         "Pod",
+				"_tenant":      "platform",
+				"_tenant_type": "platform",
+			},
+		},
+		{
+			name: "tenant and tenant_type defaults to platform when empty",
+			result: &EvalResult{
+				Matched: true,
+				Object:  map[string]any{"apiVersion": "v1", "kind": "Service"},
+				Group:   "",
+				Version: "v1",
+				Kind:    "Service",
+				// Tenant and TenantType intentionally empty
+			},
+			expected: map[string]any{
+				"apiVersion":   "v1",
+				"kind":         "Service",
+				"_tenant":      "platform",
+				"_tenant_type": "platform",
+			},
+		},
+		{
+			name: "tenant and tenant_type are set when provided",
+			result: &EvalResult{
+				Matched:    true,
+				Object:     map[string]any{"apiVersion": "v1", "kind": "ConfigMap"},
+				Group:      "",
+				Version:    "v1",
+				Kind:       "ConfigMap",
+				Tenant:     "my-project",
+				TenantType: "Project",
+			},
 			expected: map[string]any{
 				"apiVersion":   "v1",
 				"kind":         "ConfigMap",
-				"metadata":     map[string]any{"name": "test-cm"},
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
+				"_tenant":      "my-project",
+				"_tenant_type": "Project",
 			},
 		},
 		{
-			name: "multiple fields",
-			fields: map[string]any{
-				".metadata.name":                 "test-cm",
-				".spec.replicas":                 int64(3),
-				".spec.selector.matchLabels.app": "foo",
-			},
-			group:   "apps",
-			version: "v1",
-			kind:    "Deployment",
-			expected: map[string]any{
-				"apiVersion": "apps/v1",
-				"kind":       "Deployment",
-				"metadata":   map[string]any{"name": "test-cm"},
-				"spec": map[string]any{
-					"replicas": int64(3),
-					"selector": map[string]any{
-						"matchLabels": map[string]any{"app": "foo"},
+			name: "non-policy fields are present alongside policy-covered fields",
+			result: &EvalResult{
+				Matched: true,
+				// The policy only defines Fields for .metadata.name, but the full
+				// object is stored — all keys must appear in the output.
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "cfg",
+						"namespace": "ns",
+						"labels":    map[string]any{"app": "search"},
+					},
+					"data": map[string]any{
+						"extra-key": "extra-value",
 					},
 				},
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
+				Group:   "",
+				Version: "v1",
+				Kind:    "ConfigMap",
 			},
-		},
-		{
-			name:    "nested brackets",
-			fields:  map[string]any{".data['config.yaml']": "content"},
-			group:   "",
-			version: "v1",
-			kind:    "ConfigMap",
-			expected: map[string]any{
-				"apiVersion":   "v1",
-				"kind":         "ConfigMap",
-				"data":         map[string]any{"config.yaml": "content"},
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
-			},
-		},
-		{
-			name: "mixed paths sharing prefix (merging)",
-			fields: map[string]any{
-				".metadata.name":      "test",
-				".metadata.namespace": "default",
-			},
-			group:   "",
-			version: "v1",
-			kind:    "Pod",
-			expected: map[string]any{
-				"apiVersion": "v1",
-				"kind":       "Pod",
-				"metadata": map[string]any{
-					"name":      "test",
-					"namespace": "default",
-				},
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
-			},
-		},
-		{
-			name: "mixed dot and bracket notation merging",
-			fields: map[string]any{
-				".spec.selector['app']":    "backend",
-				".spec.selector.component": "core",
-			},
-			group:   "apps",
-			version: "v1",
-			kind:    "Deployment",
-			expected: map[string]any{
-				"apiVersion": "apps/v1",
-				"kind":       "Deployment",
-				"spec": map[string]any{
-					"selector": map[string]any{
-						"app":       "backend",
-						"component": "core",
-					},
-				},
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
-			},
-		},
-		{
-			name: "array indices as map keys (multiple items)",
-			fields: map[string]any{
-				".spec.ports[0].port":       int64(80),
-				".spec.ports[0].targetPort": int64(8080),
-				".spec.ports[0].name":       "http",
-				".spec.ports[1].port":       int64(443),
-				".spec.ports[1].targetPort": int64(8443),
-				".spec.ports[1].name":       "https",
-			},
-			group:   "apps",
-			version: "v1",
-			kind:    "StatefulSet",
-			expected: map[string]any{
-				"apiVersion": "apps/v1",
-				"kind":       "StatefulSet",
-				"spec": map[string]any{
-					"ports": map[string]any{
-						"0": map[string]any{
-							"port":       int64(80),
-							"targetPort": int64(8080),
-							"name":       "http",
-						},
-						"1": map[string]any{
-							"port":       int64(443),
-							"targetPort": int64(8443),
-							"name":       "https",
-						},
-					},
-				},
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
-			},
-		},
-		{
-			name: "deeply nested mix",
-			fields: map[string]any{
-				".status.conditions[0].type":        "Ready",
-				".status.conditions[0].status":      "True",
-				".status.containerStatuses[0].name": "main",
-				".status.hostIP":                    "10.0.0.1",
-			},
-			group:   "",
-			version: "v1",
-			kind:    "Pod",
-			expected: map[string]any{
-				"apiVersion": "v1",
-				"kind":       "Pod",
-				"status": map[string]any{
-					"conditions": map[string]any{
-						"0": map[string]any{
-							"type":   "Ready",
-							"status": "True",
-						},
-					},
-					"containerStatuses": map[string]any{
-						"0": map[string]any{
-							"name": "main",
-						},
-					},
-					"hostIP": "10.0.0.1",
-				},
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
-			},
-		},
-		{
-			name: "deep nesting level 5",
-			fields: map[string]any{
-				".a.b.c.d.e": "deep",
-				".a.b.c.f":   "shallow",
-			},
-			group:   "example.com",
-			version: "v1",
-			kind:    "CustomResource",
-			expected: map[string]any{
-				"apiVersion": "example.com/v1",
-				"kind":       "CustomResource",
-				"a": map[string]any{
-					"b": map[string]any{
-						"c": map[string]any{
-							"d": map[string]any{
-								"e": "deep",
-							},
-							"f": "shallow",
-						},
-					},
-				},
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
-			},
-		},
-		{
-			name: "special characters in keys",
-			fields: map[string]any{
-				".metadata.annotations['example.com/managed-by']": "controller",
-				".metadata.labels['app.kubernetes.io/name']":      "myapp",
-				".data['config.json']":                            "{}",
-			},
-			group:   "",
-			version: "v1",
-			kind:    "ConfigMap",
 			expected: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
 				"metadata": map[string]any{
+					"name":      "cfg",
+					"namespace": "ns",
+					"labels":    map[string]any{"app": "search"},
+				},
+				"data":         map[string]any{"extra-key": "extra-value"},
+				"_tenant":      "platform",
+				"_tenant_type": "platform",
+			},
+		},
+		{
+			name: "nil Object produces minimal document with overlays only",
+			result: &EvalResult{
+				Matched: true,
+				Object:  nil,
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+			expected: map[string]any{
+				"apiVersion":   "apps/v1",
+				"kind":         "Deployment",
+				"_tenant":      "platform",
+				"_tenant_type": "platform",
+			},
+		},
+		{
+			name: "Secret data and stringData are stripped; other fields preserved",
+			result: &EvalResult{
+				Matched: true,
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]any{
+						"name":   "my-secret",
+						"labels": map[string]any{"app": "auth"},
+					},
+					"type": "kubernetes.io/tls",
+					"data": map[string]any{
+						"tls.crt": "REDACTED",
+						"tls.key": "REDACTED",
+					},
+					"stringData": map[string]any{
+						"password": "hunter2",
+					},
+				},
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+			},
+			expected: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]any{
+					"name":   "my-secret",
+					"labels": map[string]any{"app": "auth"},
+				},
+				"type":         "kubernetes.io/tls",
+				"_tenant":      "platform",
+				"_tenant_type": "platform",
+			},
+		},
+		{
+			name: "last-applied-configuration annotation is stripped; other annotations preserved",
+			result: &EvalResult{
+				Matched: true,
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]any{
+						"name": "my-deploy",
+						"annotations": map[string]any{
+							"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"apps/v1","kind":"Deployment"}`,
+							"custom.io/owner": "team-a",
+						},
+					},
+				},
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+			expected: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]any{
+					"name": "my-deploy",
 					"annotations": map[string]any{
-						"example.com/managed-by": "controller",
-					},
-					"labels": map[string]any{
-						"app.kubernetes.io/name": "myapp",
-					},
-				},
-				"data": map[string]any{
-					"config.json": "{}",
-				},
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
-			},
-		},
-		{
-			name: "root level keys without dot",
-			fields: map[string]any{
-				"kind":       "Service",
-				"apiVersion": "v1",
-			},
-			group:   "",
-			version: "v2", // Policy version should overwrite the one from fields
-			kind:    "ServiceOverride",
-			expected: map[string]any{
-				"kind":         "ServiceOverride",
-				"apiVersion":   "v2",
-				"_tenant":      "platform",
-				"_tenant_type": "platform",
-			},
-		},
-		{
-			name: "multiple bracket segments",
-			fields: map[string]any{
-				".spec['selector']['app']": "foo",
-				".data['key']['subkey']":   "bar",
-			},
-			group:   "",
-			version: "v1",
-			kind:    "ConfigMap",
-			expected: map[string]any{
-				"apiVersion": "v1",
-				"kind":       "ConfigMap",
-				"spec": map[string]any{
-					"selector": map[string]any{
-						"app": "foo",
-					},
-				},
-				"data": map[string]any{
-					"key": map[string]any{
-						"subkey": "bar",
+						"custom.io/owner": "team-a",
 					},
 				},
 				"_tenant":      "platform",
 				"_tenant_type": "platform",
 			},
-		},
-		{
-			name: "conflict: scalar vs map (last write wins structurally)",
-			fields: map[string]any{
-				".a":   "scalar-value", // This sets "a" = "scalar-value"
-				".a.b": "nested-value", // This requires "a" to be a map. Logic should overwrite "a" with map {"b": "nested-value"}
-			},
-			group:    "x",
-			version:  "v1",
-			kind:     "Y",
-			expected: nil, // skip
 		},
 	}
 
 	for _, tt := range tests {
-		if tt.expected == nil {
-			continue
-		}
 		t.Run(tt.name, func(t *testing.T) {
-			r := &EvalResult{
-				Matched: true,
-				Fields:  tt.fields,
-				Group:   tt.group,
-				Version: tt.version,
-				Kind:    tt.kind,
-			}
-			doc := r.Transform()
-
-			// Use assert.Equal which compares map structure values deeply
+			doc := tt.result.Transform()
 			assert.Equal(t, tt.expected, doc)
-
-			// Debug output for visual verification
-			b, _ := json.MarshalIndent(doc, "", "  ")
-			t.Logf("Result: %s", string(b))
 		})
 	}
+}
+
+// TestEvalResult_Transform_SourceNotMutated verifies that calling Transform()
+// does not modify the caller's original u.Object map.
+func TestEvalResult_Transform_SourceNotMutated(t *testing.T) {
+	sourceObject := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name": "my-pod",
+			"managedFields": []any{
+				map[string]any{"manager": "kubectl"},
+			},
+		},
+		"spec": map[string]any{"nodeName": "node-1"},
+	}
+
+	// Snapshot what we expect the source to look like (unchanged) after Transform.
+	snapshotMeta := map[string]any{
+		"name": "my-pod",
+		"managedFields": []any{
+			map[string]any{"manager": "kubectl"},
+		},
+	}
+
+	r := &EvalResult{
+		Matched: true,
+		Object:  sourceObject,
+		Group:   "",
+		Version: "v1",
+		Kind:    "Pod",
+	}
+
+	doc := r.Transform()
+
+	// The doc must NOT have managedFields.
+	require.IsType(t, map[string]any{}, doc["metadata"])
+	docMeta := doc["metadata"].(map[string]any)
+	assert.NotContains(t, docMeta, "managedFields", "doc should have managedFields stripped")
+
+	// The source object's metadata must still have managedFields intact.
+	sourceMeta, ok := sourceObject["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, snapshotMeta, sourceMeta, "source metadata must be unchanged after Transform()")
+}
+
+// TestEvalResult_Transform_SecretSourceNotMutated verifies that calling Transform()
+// on a Secret does not remove data/stringData from the caller's original object.
+func TestEvalResult_Transform_SecretSourceNotMutated(t *testing.T) {
+	secretData := map[string]any{"password": "s3cr3t"}
+	secretStringData := map[string]any{"token": "abc123"}
+	sourceObject := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]any{
+			"name": "my-secret",
+		},
+		"type":       "Opaque",
+		"data":       secretData,
+		"stringData": secretStringData,
+	}
+
+	r := &EvalResult{
+		Matched: true,
+		Object:  sourceObject,
+		Group:   "",
+		Version: "v1",
+		Kind:    "Secret",
+	}
+
+	doc := r.Transform()
+
+	// The doc must NOT contain data or stringData.
+	assert.NotContains(t, doc, "data", "doc should have Secret data stripped")
+	assert.NotContains(t, doc, "stringData", "doc should have Secret stringData stripped")
+
+	// The source object must still have data and stringData intact.
+	assert.Equal(t, secretData, sourceObject["data"], "source Secret data must be unchanged after Transform()")
+	assert.Equal(t, secretStringData, sourceObject["stringData"], "source Secret stringData must be unchanged after Transform()")
 }

--- a/pkg/apis/search/v1alpha1/policy_types.go
+++ b/pkg/apis/search/v1alpha1/policy_types.go
@@ -95,7 +95,7 @@ type PolicyCondition struct {
 	Expression string `json:"expression"`
 }
 
-// FieldPolicy defines how a resource field should be indexed and how they behave in search operations.
+// FieldPolicy defines how a resource field behaves in search operations.
 type FieldPolicy struct {
 	// Path is the JSONPath to the field value.
 	// Supports nested paths and map key access using bracket notation.

--- a/pkg/apis/search/v1alpha1/policy_types.go
+++ b/pkg/apis/search/v1alpha1/policy_types.go
@@ -54,7 +54,7 @@ type ResourceIndexPolicySpec struct {
 	// +listMapKey=name
 	Conditions []PolicyCondition `json:"conditions,omitempty"`
 
-	// Fields defines which fields from the resource are indexed.
+	// Fields defines which fields from the resource are searchable.
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=10
 	// +listType=map

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -288,7 +288,7 @@ func schema_pkg_apis_search_v1alpha1_ResourceIndexPolicySpec(ref common.Referenc
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Fields defines which fields from the resource are indexed.",
+							Description: "Fields defines which fields from the resource are searchable.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -90,7 +90,7 @@ func schema_pkg_apis_search_v1alpha1_FieldPolicy(ref common.ReferenceCallback) c
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "FieldPolicy defines how a resource field should be indexed and how they behave in search operations.",
+				Description: "FieldPolicy defines how a resource field behaves in search operations.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"path": {

--- a/test/e2e/search-flow/chainsaw-test.yaml
+++ b/test/e2e/search-flow/chainsaw-test.yaml
@@ -4,11 +4,13 @@ metadata:
   name: search-flow
 spec:
   description: |
-    End-to-end tests for the full search flow using the Kubernetes aggregated API
-    (ResourceSearchQuery). Targets Secrets to avoid ResourceIndexPolicy conflicts
-    with parallel test suites. Covers happy paths (H1: search by name, H2: search
-    by annotation, H3: CEL condition matching) and negative paths (N1: empty results,
-    N2: CEL condition exclusion, N3: duplicate field path rejection).
+    End-to-end tests for the full search flow using the Kubernetes aggregated
+    API (ResourceSearchQuery). Targets Secrets to avoid ResourceIndexPolicy
+    conflicts with parallel test suites. Covers happy paths (H1: search by
+    name, H2: search by annotation, H3: CEL condition matching), full index
+    state (F1: non-policy field present in returned hit, F2: full-doc indexing
+    must not widen the searchable surface) negative paths (N1: empty results,
+    N2: CEL condition exclusion , N3: duplicate field path rejection).
 
   namespace: default
 
@@ -87,7 +89,7 @@ spec:
                 value: "True"
 
     # =========================================================================
-    # Step 3: Create the primary indexed Secret (for H1, H2, H3)
+    # Step 3: Create the primary indexed Secret (for H1, H2, H3, F1, F2)
     # =========================================================================
     - name: create-indexed-secret
       description: "Creates Secret in default namespace that matches the policy condition"
@@ -101,6 +103,8 @@ spec:
               kubectl annotate -f - --local -o yaml \
                 e2e.search.test/description=unique-e2e-search-description-alpha7 \
                 e2e.search.test/app-label=e2e-app-value | \
+              kubectl label -f - --local -o yaml \
+                e2e-invisible-label=notindexed-unique-xq7 | \
               kubectl apply -f -
             check:
               ($error): ~
@@ -213,6 +217,52 @@ spec:
               EOF
               )
               echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "e2e-search-target-secret")] | length > 0'
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # F1: Full-document indexing — non-policy field present in returned hit
+    # =========================================================================
+    - name: F1-full-doc-hit-contains-non-policy-fields
+      description: "F1: Hit document must contain fields not declared in the policy (full-doc indexing)"
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              RESULT=$(cat <<EOF | kubectl create -f - -o json
+              apiVersion: search.miloapis.com/v1alpha1
+              kind: ResourceSearchQuery
+              metadata:
+                name: f1-full-doc-check
+              spec:
+                targetResources:
+                  - group: ""
+                    version: v1
+                    kind: Secret
+                query: "e2e-search-target-secret"
+                limit: 10
+              EOF
+              )
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "e2e-search-target-secret") | select(.resource.metadata.namespace == "default")] | length > 0' && \
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "e2e-search-target-secret") | select(.resource.metadata.labels["e2e-invisible-label"] == "notindexed-unique-xq7")] | length > 0'
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # F2: full-doc indexing must not widen the searchable surface
+    # =========================================================================
+    - name: F2-index-searchable-attributes-match-policy
+      description: "F2: full-doc indexing must not widen the searchable surface"
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              kubectl exec -n meilisearch-system meilisearch-0 -- \
+                curl -sf \
+                  -H "Authorization: Bearer search-master-key" \
+                  http://localhost:7700/indexes/_v1_Secret/settings/searchable-attributes \
+              | jq -e --argjson exp '["metadata.annotations.e2e.search.test/app-label","metadata.annotations.e2e.search.test/description","metadata.name"]' \
+                  'sort == ($exp | sort)'
             check:
               ($error): ~
 


### PR DESCRIPTION
# Full-Document Indexing for Search

Resolves #94

## Summary

`Evaluate()` now stores the full source object on `EvalResult`; `Transform()` deep-copies it, strips noise/secrets, and overlays policy-derived metadata. `ResourceIndexPolicy.Spec.Fields` no longer drives storage - it only governs which fields are registered as Meilisearch `searchableAttributes`. The full source object is always stored as the document.

## API compatibility

`Fields[]` behavior is preserved for declared fields: `Searchable: true` -> queryable, `Searchable: false` -> present in document, not queryable. What shifts is **undeclared** fields - these used to be absent from documents and are now present. Existing policies remain correct; their `Searchable: false` entries become redundant rather than wrong.

## Migration

No automatic reindex on rollout. Existing indexes will continue to serve projection-shape documents until the matching `ResourceIndexPolicy` is updated, which would cause a reindex.

## Tests

- `transform_test.go` covers each strip case, overlay logic, and source-mutation safety. 
- E2E coverage in `chainsaw-test.yaml` adds F1 (full document present in hits) and F2 (searchable surface unchanged).
