### PR TITLE
fix(search): seed spec hash to force reindex of all policies

### DIFF
--- a/internal/utils/search.go
+++ b/internal/utils/search.go
@@ -14,14 +14,21 @@ func GetSearchIndex(tg searchv1alpha1.TargetResource) string {
 	return strings.ReplaceAll(res, ".", "-")
 }
 
-// ComputeSpecHash returns a SHA-256 hex digest of the policy spec.
+// TODO: remove reindex seed in flavor of a API for forcing reindexing
+// reindexSeed is mixed into every spec hash. Bump to force a full re-index of all policies.
+const reindexSeed = "2026-05-19"
+
+// ComputeSpecHash returns a seeded SHA-256 hex digest of the policy spec.
 // Used by both the controller (to detect spec changes) and the re-index
 // consumer (to verify cache freshness before evaluating).
+// Bump reindexSeed to force a full re-index of all policies.
 func ComputeSpecHash(spec *searchv1alpha1.ResourceIndexPolicySpec) string {
 	b, err := json.Marshal(spec)
 	if err != nil {
 		return ""
 	}
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:])
+	h := sha256.New()
+	h.Write(b)
+	h.Write([]byte(reindexSeed))
+	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
## Summary

- Adds a `reindexSeed` constant to `utils.ComputeSpecHash` that is mixed into every policy spec hash
- Bumping the constant (e.g. to today's date) causes every `ResourceIndexPolicy`'s stored `CurrentGeneration` hash to become stale, triggering a full reindex without requiring any spec change
- Both the controller and the reindex consumer call the same `utils.ComputeSpecHash`, so the hashes they produce stay in sync

## Context

This is a **provisional fix** to unblock forced reconciliation of resources. A proper API for triggering reindexes on demand should replace this mechanism (see the companion issue).

## Test plan

- [ ] Bump `reindexSeed` in `internal/utils/search.go` and verify the controller detects a hash mismatch and publishes reindex messages for all policies
- [ ] Verify the reindex consumer's hash verification (`event.SpecHash` vs `utils.ComputeSpecHash`) still matches so messages are not NAK'd

🤖 Generated with [Claude Code](https://claude.com/claude-code)