### PR TITLE
fix(indexer): treat updates to terminating resources as deletes

### DIFF
--- a/internal/indexer/consumer.go
+++ b/internal/indexer/consumer.go
@@ -118,22 +118,7 @@ func (i *Indexer) Start(ctx context.Context) error {
 
 		// Handle deletions separately
 		if event.Verb == deleteVerb {
-			docID := resolveUID(&event)
-			if docID == "" {
-				logMissingUIDDetails(&event)
-				msg.Ack()
-				return
-			}
-
-			// Queue delete for all policies since we don't know which one it matched
-			for _, cp := range i.policyCache.GetPolicies() {
-				// Skip if index name is not set yet
-				if cp.Policy.Status.IndexName == "" {
-					continue
-				}
-
-				i.batcher.QueueDelete(cp.Policy.Status.IndexName, docID, &msg)
-			}
+			i.handleDelete(msg, &event)
 			return
 		}
 
@@ -145,6 +130,16 @@ func (i *Indexer) Start(ctx context.Context) error {
 
 		// Build unstructured from responseObject if present
 		obj := &unstructured.Unstructured{Object: event.ResponseObject}
+
+		// Treat create/update/patch events on terminating resources as deletes.
+		// For resources with finalizers, the terminal audit event is the update
+		// that removes the last finalizer (deletionTimestamp still set) — the
+		// physical etcd purge emits no delete-verb event. Upserting here would
+		// resurrect the document the earlier delete event just removed.
+		if obj.GetDeletionTimestamp() != nil {
+			i.handleDelete(msg, &event)
+			return
+		}
 
 		// Attempt to resolve UID using helper
 		resourceUID := resolveUID(&event)
@@ -223,4 +218,26 @@ func (i *Indexer) Start(ctx context.Context) error {
 	<-ctx.Done()
 	klog.Info("Shutting down indexer...")
 	return nil
+}
+
+// handleDelete queues a delete for the event's resource across all policies
+// with an index. It is used for delete-verb events and for create/update/patch
+// events on terminating resources (deletionTimestamp set).
+func (i *Indexer) handleDelete(msg jetstream.Msg, event *auditEvent) {
+	docID := resolveUID(event)
+	if docID == "" {
+		logMissingUIDDetails(event)
+		msg.Ack()
+		return
+	}
+
+	// Queue delete for all policies since we don't know which one it matched
+	for _, cp := range i.policyCache.GetPolicies() {
+		// Skip if index name is not set yet
+		if cp.Policy.Status.IndexName == "" {
+			continue
+		}
+
+		i.batcher.QueueDelete(cp.Policy.Status.IndexName, docID, &msg)
+	}
 }

--- a/internal/indexer/consumer_test.go
+++ b/internal/indexer/consumer_test.go
@@ -283,3 +283,152 @@ func TestIndexer_Consume_Delete(t *testing.T) {
 
 	mockSearch.AssertExpectations(t)
 }
+
+func TestIndexer_Consume_TerminatingResource_QueuesDelete(t *testing.T) {
+	// Update/patch events on a terminating resource (deletionTimestamp set)
+	// must queue a delete instead of an upsert. The finalizer-removal update is
+	// the terminal audit event for the resource, so an upsert would resurrect
+	// the document the earlier delete event removed.
+	for _, verb := range []string{"update", "patch"} {
+		t.Run(verb, func(t *testing.T) {
+			policy := &v1alpha1.ResourceIndexPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-policy"},
+				Spec: v1alpha1.ResourceIndexPolicySpec{
+					TargetResource: v1alpha1.TargetResource{Kind: "Pod", Version: "v1"},
+					Conditions: []v1alpha1.PolicyCondition{
+						{Name: "all", Expression: "true"},
+					},
+				},
+				Status: v1alpha1.ResourceIndexPolicyStatus{
+					IndexName:  "pod-index",
+					Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}},
+				},
+			}
+
+			env, _ := internalcel.NewEnv()
+			policyCache := &PolicyCache{
+				policies: make(map[string]*policyevaluation.CachedPolicy),
+				celEnv:   env,
+			}
+			policyCache.upsertPolicy(policy)
+
+			mockSearch := new(MockSearchClient)
+			batcher := NewBatcher(mockSearch, BatchConfig{BatchSize: 1, FlushInterval: 1 * time.Minute})
+
+			mockConsumer := new(MockConsumer)
+			mockContext := new(MockConsumeContext)
+			mockContext.On("Stop").Return()
+
+			// The policy would match this resource, but deletionTimestamp is set.
+			event := map[string]interface{}{
+				"verb":    verb,
+				"auditID": "789",
+				"objectRef": map[string]string{
+					"resource": "pods",
+					"name":     "mypod",
+				},
+				"responseObject": map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name":              "mypod",
+						"uid":               "pod-uid-terminating",
+						"deletionTimestamp": "2026-07-08T00:00:00Z",
+					},
+				},
+			}
+			eventBytes, _ := json.Marshal(event)
+
+			msg := &MockJetStreamMsg{seq: 102}
+			msg.On("Data").Return(eventBytes)
+			msg.On("Ack").Return(nil)
+
+			mockConsumer.On("Consume", mock.Anything).Return(mockContext, []jetstream.Msg{msg}, nil)
+
+			// Expect Delete on Search Client, and no upsert.
+			mockSearch.On("DeleteDocumentsAsync", "pod-index", mock.MatchedBy(func(ids []string) bool {
+				return len(ids) == 1 && ids[0] == "pod-uid-terminating"
+			})).Return(nil, nil).Once()
+			mockSearch.On("WaitForTasks", mock.Anything).Return(nil, nil).Once()
+
+			indexer := NewIndexer(mockConsumer, policyCache, batcher, false)
+			ctx, cancel := context.WithCancel(context.Background())
+
+			go indexer.Start(ctx)
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+
+			mockSearch.AssertExpectations(t)
+			mockSearch.AssertNotCalled(t, "AddDocumentsAsync", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestIndexer_Consume_UpdateWithoutDeletionTimestamp_Upserts(t *testing.T) {
+	// An update event without deletionTimestamp must still upsert as before.
+	policy := &v1alpha1.ResourceIndexPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-policy"},
+		Spec: v1alpha1.ResourceIndexPolicySpec{
+			TargetResource: v1alpha1.TargetResource{Kind: "Pod", Version: "v1"},
+			Conditions: []v1alpha1.PolicyCondition{
+				{Name: "all", Expression: "true"},
+			},
+		},
+		Status: v1alpha1.ResourceIndexPolicyStatus{
+			IndexName:  "pod-index",
+			Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}},
+		},
+	}
+
+	env, _ := internalcel.NewEnv()
+	policyCache := &PolicyCache{
+		policies: make(map[string]*policyevaluation.CachedPolicy),
+		celEnv:   env,
+	}
+	policyCache.upsertPolicy(policy)
+
+	mockSearch := new(MockSearchClient)
+	batcher := NewBatcher(mockSearch, BatchConfig{BatchSize: 1, FlushInterval: 1 * time.Minute})
+
+	mockConsumer := new(MockConsumer)
+	mockContext := new(MockConsumeContext)
+	mockContext.On("Stop").Return()
+
+	event := map[string]interface{}{
+		"verb":    "update",
+		"auditID": "790",
+		"objectRef": map[string]string{
+			"resource": "pods",
+			"name":     "mypod",
+		},
+		"responseObject": map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name": "mypod",
+				"uid":  "pod-uid-live",
+			},
+		},
+	}
+	eventBytes, _ := json.Marshal(event)
+
+	msg := &MockJetStreamMsg{seq: 103}
+	msg.On("Data").Return(eventBytes)
+	msg.On("Ack").Return(nil)
+
+	mockConsumer.On("Consume", mock.Anything).Return(mockContext, []jetstream.Msg{msg}, nil)
+
+	// Expect Upsert on Search Client, and no delete.
+	mockSearch.On("AddDocumentsAsync", "pod-index", mock.Anything).Return(nil, nil).Once()
+	mockSearch.On("WaitForTasks", mock.Anything).Return(nil, nil).Once()
+
+	indexer := NewIndexer(mockConsumer, policyCache, batcher, false)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go indexer.Start(ctx)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	mockSearch.AssertExpectations(t)
+	mockSearch.AssertNotCalled(t, "DeleteDocumentsAsync", mock.Anything, mock.Anything)
+}

--- a/internal/indexer/reindex_consumer.go
+++ b/internal/indexer/reindex_consumer.go
@@ -83,6 +83,17 @@ func (r *ReindexConsumer) processTargetedEvent(msg jetstream.Msg, event ReindexE
 		return
 	}
 
+	// A terminating resource (deletionTimestamp set) must not be searchable:
+	// the audit path treats its terminal finalizer-removal update as a delete,
+	// so a re-index must not resurrect the document. Deleting needs no policy
+	// evaluation, so this is checked before the cache lookup.
+	if obj.GetDeletionTimestamp() != nil {
+		klog.V(4).Infof("ReindexConsumer: resource %s/%s is terminating, deleting from index %s (id=%s)",
+			obj.GetNamespace(), obj.GetName(), event.IndexName, event.ID)
+		r.batcher.QueueDelete(event.IndexName, resourceUID, &msg)
+		return
+	}
+
 	cp := r.policyCache.GetPolicy(event.PolicyName)
 	if cp == nil {
 		// Policy not in cache yet — NAK so the message is redelivered

--- a/internal/indexer/reindex_consumer_test.go
+++ b/internal/indexer/reindex_consumer_test.go
@@ -1,0 +1,143 @@
+package indexer
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/mock"
+	internalcel "go.miloapis.net/search/internal/cel"
+	policyevaluation "go.miloapis.net/search/internal/policy/evaluation"
+	"go.miloapis.net/search/pkg/apis/search/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// newReindexTestPolicyCache builds a PolicyCache holding a single match-all
+// Pod policy named "pod-policy" with index "pod-index".
+func newReindexTestPolicyCache(t *testing.T) *PolicyCache {
+	t.Helper()
+
+	policy := &v1alpha1.ResourceIndexPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-policy"},
+		Spec: v1alpha1.ResourceIndexPolicySpec{
+			TargetResource: v1alpha1.TargetResource{Kind: "Pod", Version: "v1"},
+			Conditions: []v1alpha1.PolicyCondition{
+				{Name: "all", Expression: "true"},
+			},
+		},
+		Status: v1alpha1.ResourceIndexPolicyStatus{
+			IndexName:  "pod-index",
+			Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}},
+		},
+	}
+
+	env, _ := internalcel.NewEnv()
+	policyCache := &PolicyCache{
+		policies: make(map[string]*policyevaluation.CachedPolicy),
+		celEnv:   env,
+	}
+	policyCache.upsertPolicy(policy)
+	return policyCache
+}
+
+func TestReindexConsumer_TerminatingResource_QueuesDelete(t *testing.T) {
+	// A reindex event for a terminating resource (deletionTimestamp set) must
+	// queue a delete instead of an upsert, even when the policy matches, so a
+	// re-index cannot resurrect a document the audit path evicted.
+	policyCache := newReindexTestPolicyCache(t)
+
+	mockSearch := new(MockSearchClient)
+	batcher := NewBatcher(mockSearch, BatchConfig{BatchSize: 1, FlushInterval: 1 * time.Minute})
+
+	mockConsumer := new(MockConsumer)
+	mockContext := new(MockConsumeContext)
+	mockContext.On("Stop").Return()
+
+	event := ReindexEvent{
+		ID:         "reindex-1",
+		PolicyName: "pod-policy",
+		IndexName:  "pod-index",
+		Resource: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":              "mypod",
+				"uid":               "pod-uid-terminating",
+				"deletionTimestamp": "2026-07-08T00:00:00Z",
+			},
+		},
+	}
+	eventBytes, _ := json.Marshal(event)
+
+	msg := &MockJetStreamMsg{seq: 200}
+	msg.On("Data").Return(eventBytes)
+	msg.On("Ack").Return(nil)
+
+	mockConsumer.On("Consume", mock.Anything).Return(mockContext, []jetstream.Msg{msg}, nil)
+
+	// Expect Delete on Search Client, and no upsert.
+	mockSearch.On("DeleteDocumentsAsync", "pod-index", mock.MatchedBy(func(ids []string) bool {
+		return len(ids) == 1 && ids[0] == "pod-uid-terminating"
+	})).Return(nil, nil).Once()
+	mockSearch.On("WaitForTasks", mock.Anything).Return(nil, nil).Once()
+
+	consumer := NewReindexConsumer(mockConsumer, policyCache, batcher)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go consumer.Start(ctx)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	mockSearch.AssertExpectations(t)
+	mockSearch.AssertNotCalled(t, "AddDocumentsAsync", mock.Anything, mock.Anything)
+}
+
+func TestReindexConsumer_MatchedResource_Upserts(t *testing.T) {
+	// A reindex event for a live (non-terminating) resource that matches the
+	// policy must upsert as before.
+	policyCache := newReindexTestPolicyCache(t)
+
+	mockSearch := new(MockSearchClient)
+	batcher := NewBatcher(mockSearch, BatchConfig{BatchSize: 1, FlushInterval: 1 * time.Minute})
+
+	mockConsumer := new(MockConsumer)
+	mockContext := new(MockConsumeContext)
+	mockContext.On("Stop").Return()
+
+	event := ReindexEvent{
+		ID:         "reindex-2",
+		PolicyName: "pod-policy",
+		IndexName:  "pod-index",
+		Resource: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name": "mypod",
+				"uid":  "pod-uid-live",
+			},
+		},
+	}
+	eventBytes, _ := json.Marshal(event)
+
+	msg := &MockJetStreamMsg{seq: 201}
+	msg.On("Data").Return(eventBytes)
+	msg.On("Ack").Return(nil)
+
+	mockConsumer.On("Consume", mock.Anything).Return(mockContext, []jetstream.Msg{msg}, nil)
+
+	// Expect Upsert on Search Client, and no delete.
+	mockSearch.On("AddDocumentsAsync", "pod-index", mock.Anything).Return(nil, nil).Once()
+	mockSearch.On("WaitForTasks", mock.Anything).Return(nil, nil).Once()
+
+	consumer := NewReindexConsumer(mockConsumer, policyCache, batcher)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go consumer.Start(ctx)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	mockSearch.AssertExpectations(t)
+	mockSearch.AssertNotCalled(t, "DeleteDocumentsAsync", mock.Anything, mock.Anything)
+}

--- a/test/e2e/search-flow-resource-finalizer-delete/chainsaw-test.yaml
+++ b/test/e2e/search-flow-resource-finalizer-delete/chainsaw-test.yaml
@@ -1,0 +1,227 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: search-flow-resource-finalizer-delete
+spec:
+  description: |
+    End-to-end test for deleting a resource that carries a finalizer: the resource
+    must no longer appear in search results after it is fully removed. Targets
+    PodTemplates to avoid ResourceIndexPolicy conflicts with parallel test suites.
+
+    This reproduces the "ghost entry" scenario: deleting a finalized resource only
+    sets deletionTimestamp (the indexer removes the entry), and the LAST audit event
+    the indexer ever sees for the resource is the finalizer-removal update — the
+    physical purge emits no delete event. On unfixed code the indexer treats that
+    terminal update as a normal write and re-adds the entry it just removed, so this
+    test FAILS without the fix (ghost stays searchable) and PASSES with it.
+
+    All assertions go through the consumer-facing ResourceSearchQuery API. Resources
+    are created with chainsaw-native operations and cleaned up automatically; the
+    PodTemplate's custom finalizer is removed as part of the test flow itself, so
+    auto-cleanup never blocks on it.
+
+  namespace: default
+
+  steps:
+    # =========================================================================
+    # Step 0: Create a dedicated namespace for the test resources
+    # =========================================================================
+    - name: create-test-namespace
+      description: "Creates a dedicated namespace for the finalizer-delete test"
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: e2e-resource-finalizer-delete
+
+    # =========================================================================
+    # Step 1: Create the policy for PodTemplates
+    # =========================================================================
+    - name: create-pt-policy
+      description: "Creates ResourceIndexPolicy targeting PodTemplates with e2e-ghost-test label"
+      try:
+        - apply:
+            resource:
+              apiVersion: search.miloapis.com/v1alpha1
+              kind: ResourceIndexPolicy
+              metadata:
+                name: e2e-ghost-pt-policy
+              spec:
+                targetResource:
+                  group: ""
+                  version: v1
+                  kind: PodTemplate
+                conditions:
+                  - name: is-e2e-ghost-test
+                    expression: "'e2e-ghost-test' in metadata.labels"
+                fields:
+                  - path: ".metadata.name"
+                    searchable: true
+                  - path: ".metadata.annotations['e2e.search.test/ghost-tag']"
+                    searchable: true
+
+    - name: wait-for-pt-policy-ready
+      description: "Waits for PodTemplate policy to reach Ready=True"
+      try:
+        - wait:
+            apiVersion: search.miloapis.com/v1alpha1
+            kind: ResourceIndexPolicy
+            name: e2e-ghost-pt-policy
+            timeout: 60s
+            for:
+              condition:
+                name: Ready
+                value: "True"
+
+    # =========================================================================
+    # Step 2: Create a PodTemplate WITH a custom finalizer
+    # =========================================================================
+    - name: create-podtemplate-with-finalizer
+      description: "Creates a PodTemplate carrying a custom finalizer and a unique annotation"
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: PodTemplate
+              metadata:
+                name: e2e-pt-ghost
+                namespace: e2e-resource-finalizer-delete
+                labels:
+                  e2e-ghost-test: "true"
+                annotations:
+                  e2e.search.test/ghost-tag: "ghost-finalizer-delete-vq4"
+                finalizers:
+                  - e2e.search.test/ghost-check
+              template:
+                spec:
+                  containers:
+                    - name: placeholder
+                      image: busybox:1.36
+
+    - name: wait-for-indexing
+      description: "Waits 15 seconds for the PodTemplate to be indexed"
+      try:
+        - script:
+            timeout: 20s
+            content: sleep 15
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # Step 3: Validate the pipeline — the resource must be searchable BEFORE
+    # the deletion, otherwise the post-delete assertion proves nothing.
+    # =========================================================================
+    - name: A1-search-before-delete-found
+      description: "A1: PodTemplate must be searchable by its unique annotation before deletion"
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              RESULT=$(cat <<EOF | kubectl create -f - -o json
+              apiVersion: search.miloapis.com/v1alpha1
+              kind: ResourceSearchQuery
+              metadata:
+                name: a1-search-ghost-before
+              spec:
+                targetResources:
+                  - group: ""
+                    version: v1
+                    kind: PodTemplate
+                query: "ghost-finalizer-delete-vq4"
+                limit: 10
+              EOF
+              )
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "e2e-pt-ghost")] | length > 0'
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # Step 4: Delete the PodTemplate. The finalizer blocks the actual purge,
+    # so this only sets deletionTimestamp (--wait=false or kubectl would hang).
+    # =========================================================================
+    - name: B1-delete-blocked-by-finalizer
+      description: "B1: Deletes the PodTemplate (finalizer keeps it in Terminating with deletionTimestamp set)"
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              kubectl delete podtemplate e2e-pt-ghost -n e2e-resource-finalizer-delete --wait=false
+              # The finalizer must be blocking the purge: deletionTimestamp set, object still present.
+              DT=$(kubectl get podtemplate e2e-pt-ghost -n e2e-resource-finalizer-delete \
+                -o jsonpath='{.metadata.deletionTimestamp}')
+              if [ -z "$DT" ]; then
+                echo "FAIL: deletionTimestamp not set after delete"
+                exit 1
+              fi
+              echo "PodTemplate is Terminating (deletionTimestamp=$DT)"
+              # Give the delete audit event time to reach the indexer before the
+              # finalizer-removal update, mirroring the real event ordering.
+              sleep 5
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # Step 5: Remove the finalizer. This emits the TERMINAL finalizer-removal
+    # update audit event (deletionTimestamp still set, finalizers now empty)
+    # and the API server purges the object — no further event follows.
+    # =========================================================================
+    - name: B2-remove-finalizer-triggers-purge
+      description: "B2: Removes the finalizer — emits the terminal update event and the object is purged"
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              kubectl patch podtemplate e2e-pt-ghost -n e2e-resource-finalizer-delete \
+                --type=merge -p '{"metadata":{"finalizers":null}}'
+              # The object must now disappear from the API entirely.
+              for i in $(seq 1 15); do
+                if ! kubectl get podtemplate e2e-pt-ghost -n e2e-resource-finalizer-delete >/dev/null 2>&1; then
+                  echo "PASS: PodTemplate purged from the API"
+                  exit 0
+                fi
+                sleep 1
+              done
+              echo "FAIL: PodTemplate still exists after finalizer removal"
+              exit 1
+            check:
+              ($error): ~
+
+    - name: wait-for-deletion-propagation
+      description: "Waits 30 seconds for the delete and terminal update events to propagate through the indexer"
+      try:
+        - script:
+            timeout: 35s
+            content: sleep 30
+            check:
+              ($error): ~
+
+    # =========================================================================
+    # Step 6: The deleted resource must NOT be searchable. On unfixed code the
+    # terminal finalizer-removal update re-adds the entry (the ghost) and this
+    # assertion fails.
+    # =========================================================================
+    - name: C1-search-after-delete-not-found
+      description: "C1: Deleted PodTemplate must not appear in search results (no ghost entry)"
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              RESULT=$(cat <<EOF | kubectl create -f - -o json
+              apiVersion: search.miloapis.com/v1alpha1
+              kind: ResourceSearchQuery
+              metadata:
+                name: c1-search-ghost-after
+              spec:
+                targetResources:
+                  - group: ""
+                    version: v1
+                    kind: PodTemplate
+                query: "ghost-finalizer-delete-vq4"
+                limit: 10
+              EOF
+              )
+              echo "$RESULT" | jq -e '[.status.results[]? | select(.resource.metadata.name == "e2e-pt-ghost")] | length == 0'
+            check:
+              ($error): ~


### PR DESCRIPTION
## What users experienced

Deleted resources kept showing up in search results. In staging we confirmed 120 of these ghost entries across 4 resource kinds, with new ones still appearing daily.

## Why it happened

When a resource with a finalizer is deleted, the deletion isn't final right away: the search indexer first sees the delete and correctly removes the entry, but moments later the resource's controller removes its finalizer, and that cleanup update is the very last event the indexer ever sees for the resource. The indexer treated it like any normal write and re-added the entry it had just removed — and since nothing comes after it, the ghost stayed in search forever.

## What the fix does

Resources that are in the process of being deleted are now removed from the search index instead of re-added. This applies both to the live event stream and to the reindex path, so a reindex can no longer bring back an entry that was already evicted. Treating these events as removals (rather than just ignoring them) also means the index self-heals if the original delete event was ever missed.

This stops new ghost entries from being created. A one-time cleanup of the ghosts already present in search is being handled separately.

## Test coverage

New tests cover the terminating update and patch cases (entry removed, not re-added), plus regression guards confirming that normal writes still index as before. The reindex path — which previously had no test coverage at all — now has tests for both the terminating and the normal case. An end-to-end test also walks the full ghost scenario against a real cluster — deleting a resource that has a finalizer and verifying it no longer appears anywhere in search — so any regression is caught in CI.

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
